### PR TITLE
Add MIT License implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Nathaniel J. Smith <njs@pobox.com> and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ This provides:
 
 ## License
 
-[License information to be added]
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Version History
 


### PR DESCRIPTION
## Summary
- Add LICENSE file with MIT License text as specified
- Update README.md to reference the MIT License, replacing placeholder text
- All code quality checks pass (linting, security scans, 115/116 tests passing)

## Changes
- Created LICENSE file with MIT License text for Nathaniel J. Smith and other contributors (2016)
- Updated README.md license section to properly reference the LICENSE file
- Replaced placeholder "[License information to be added]" with proper MIT License reference

## Testing
- Code formatting (black): ✅ Passed
- Import sorting (isort): ✅ Passed  
- Linting (flake8): ✅ Passed
- Security (safety + bandit): ✅ Passed
- Unit tests: 115/116 passed (1 unrelated test failure in settings)
- Note: One test failure in test_settings.py appears to be environment-related and not connected to license changes

## Verification
The MIT License implementation is complete and follows the exact specifications provided in the requirements.