### PR TITLE
Add dotenv console script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ packages = ["src/auto_slopp"]
 
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
+dotenv = "dotenv.__main__:cli"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
## Summary
- Added console_scripts entry point for dotenv: `dotenv = dotenv.__main__:cli`
- This enables running the dotenv CLI tool via `dotenv` command after installation