### PR TITLE
Add flake8 extension for McCabe complexity checker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 120
+max-complexity = 8
+extend-ignore = E203,W503
+
+[flake8.extension]
+C90 = mccabe:McCabeChecker


### PR DESCRIPTION
This PR adds the flake8 extension configuration for the McCabe complexity checker (C90) in setup.cfg.