### PR TITLE
Add pytest, py, and _pytest workers

### DIFF
--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -5,12 +5,18 @@ This package contains all worker implementations organized by functionality:
 """
 
 # Import all workers to make them available for discovery
+from auto_slopp.workers.py_worker import PyWorker
+from auto_slopp.workers.pytest_worker import PytestWorker
 from auto_slopp.workers.renovate_test_worker import RenovateTestWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 from auto_slopp.workers.task_processor_worker import TaskProcessorWorker
+from auto_slopp.workers.underscore_pytest_worker import UnderscorePytestWorker
 
 __all__ = [
+    "PyWorker",
+    "PytestWorker",
     "RenovateTestWorker",
     "StaleBranchCleanupWorker",
     "TaskProcessorWorker",
+    "UnderscorePytestWorker",
 ]

--- a/src/auto_slopp/workers/py_worker.py
+++ b/src/auto_slopp/workers/py_worker.py
@@ -1,0 +1,83 @@
+"""Python file worker for handling .py files."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from auto_slopp.worker import Worker
+
+
+class PyWorker(Worker):
+    """Worker for handling Python (.py) files.
+
+    This worker scans the repository for Python files.
+    """
+
+    def __init__(self, exclude_patterns: list[str] | None = None):
+        """Initialize the PyWorker.
+
+        Args:
+            exclude_patterns: List of patterns to exclude from results
+        """
+        self.exclude_patterns = exclude_patterns or [
+            "__pycache__",
+            ".venv",
+            "pytest_cache",
+            "venv",
+            ".git",
+        ]
+        self.logger = logging.getLogger("auto_slopp.workers.PyWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the Python file worker task.
+
+        Args:
+            repo_path: Path to the repository directory
+            task_path: Path to the task directory or file
+
+        Returns:
+            Dictionary containing information about found Python files
+        """
+        self.logger.info(f"PyWorker starting with repo_path: {repo_path}")
+
+        if not repo_path.exists():
+            return {
+                "worker_name": "PyWorker",
+                "success": False,
+                "error": f"Repository path does not exist: {repo_path}",
+                "files_found": 0,
+            }
+
+        py_files = []
+        for f in repo_path.rglob("*.py"):
+            if not any(excl in f.parts for excl in self.exclude_patterns):
+                py_files.append(f)
+
+        py_files = sorted(set(py_files))
+
+        total_lines = 0
+        file_types = {"test": 0, "module": 0, "other": 0}
+        for f in py_files:
+            if f.is_file():
+                try:
+                    lines = len(f.read_text().splitlines())
+                    total_lines += lines
+                    if "test" in f.name:
+                        file_types["test"] += 1
+                    elif "__init__" in f.name:
+                        file_types["module"] += 1
+                    else:
+                        file_types["other"] += 1
+                except Exception:
+                    pass
+
+        return {
+            "worker_name": "PyWorker",
+            "success": True,
+            "repo_path": str(repo_path),
+            "task_path": str(task_path),
+            "files_found": len(py_files),
+            "total_lines": total_lines,
+            "file_types": file_types,
+            "py_files": [str(f.relative_to(repo_path)) for f in py_files[:10]],
+        }

--- a/src/auto_slopp/workers/pytest_worker.py
+++ b/src/auto_slopp/workers/pytest_worker.py
@@ -1,0 +1,68 @@
+"""Pytest worker for handling pytest-related files."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from auto_slopp.worker import Worker
+
+
+class PytestWorker(Worker):
+    """Worker for handling pytest-related files and test execution.
+
+    This worker scans the repository for pytest-related files and
+    provides information about them.
+    """
+
+    def __init__(self, file_pattern: str = "test_*.py"):
+        """Initialize the PytestWorker.
+
+        Args:
+            file_pattern: Pattern to match pytest test files
+        """
+        self.file_pattern = file_pattern
+        self.logger = logging.getLogger("auto_slopp.workers.PytestWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the pytest worker task.
+
+        Args:
+            repo_path: Path to the repository directory
+            task_path: Path to the task directory or file
+
+        Returns:
+            Dictionary containing information about found pytest files
+        """
+        self.logger.info(f"PytestWorker starting with repo_path: {repo_path}")
+
+        if not repo_path.exists():
+            return {
+                "worker_name": "PytestWorker",
+                "success": False,
+                "error": f"Repository path does not exist: {repo_path}",
+                "files_found": 0,
+            }
+
+        test_files = list(repo_path.rglob(self.file_pattern))
+        test_files.extend(list(repo_path.rglob("*_test.py")))
+
+        test_files = sorted(set(test_files))
+
+        total_lines = 0
+        for f in test_files:
+            if f.is_file():
+                try:
+                    total_lines += len(f.read_text().splitlines())
+                except Exception:
+                    pass
+
+        return {
+            "worker_name": "PytestWorker",
+            "success": True,
+            "repo_path": str(repo_path),
+            "task_path": str(task_path),
+            "file_pattern": self.file_pattern,
+            "files_found": len(test_files),
+            "total_lines": total_lines,
+            "test_files": [str(f.relative_to(repo_path)) for f in test_files[:10]],
+        }

--- a/src/auto_slopp/workers/underscore_pytest_worker.py
+++ b/src/auto_slopp/workers/underscore_pytest_worker.py
@@ -1,0 +1,65 @@
+"""Underscore pytest worker for handling _pytest* files."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from auto_slopp.worker import Worker
+
+
+class UnderscorePytestWorker(Worker):
+    """Worker for handling files starting with _pytest.
+
+    This worker scans the repository for files matching _pytest* pattern.
+    """
+
+    def __init__(self, file_pattern: str = "_pytest*"):
+        """Initialize the UnderscorePytestWorker.
+
+        Args:
+            file_pattern: Pattern to match _pytest files
+        """
+        self.file_pattern = file_pattern
+        self.logger = logging.getLogger("auto_slopp.workers.UnderscorePytestWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the _pytest worker task.
+
+        Args:
+            repo_path: Path to the repository directory
+            task_path: Path to the task directory or file
+
+        Returns:
+            Dictionary containing information about found _pytest files
+        """
+        self.logger.info(f"UnderscorePytestWorker starting with repo_path: {repo_path}")
+
+        if not repo_path.exists():
+            return {
+                "worker_name": "UnderscorePytestWorker",
+                "success": False,
+                "error": f"Repository path does not exist: {repo_path}",
+                "files_found": 0,
+            }
+
+        test_files = list(repo_path.rglob(self.file_pattern))
+        test_files = sorted(set(test_files))
+
+        total_lines = 0
+        for f in test_files:
+            if f.is_file():
+                try:
+                    total_lines += len(f.read_text().splitlines())
+                except Exception:
+                    pass
+
+        return {
+            "worker_name": "UnderscorePytestWorker",
+            "success": True,
+            "repo_path": str(repo_path),
+            "task_path": str(task_path),
+            "file_pattern": self.file_pattern,
+            "files_found": len(test_files),
+            "total_lines": total_lines,
+            "test_files": [str(f.relative_to(repo_path)) for f in test_files[:10]],
+        }

--- a/tests/test_py_worker.py
+++ b/tests/test_py_worker.py
@@ -1,0 +1,59 @@
+"""Tests for PyWorker."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from auto_slopp.workers.py_worker import PyWorker
+
+
+class TestPyWorker:
+    """Tests for PyWorker."""
+
+    def test_initialization(self):
+        """Test worker initialization."""
+        worker = PyWorker()
+        assert "__pycache__" in worker.exclude_patterns
+
+    def test_run_with_existing_path(self):
+        """Test run with existing directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            (repo_path / "test_file.py").write_text("print('hello')")
+            (repo_path / "__init__.py").write_text("")
+            (repo_path / "module.py").write_text("def foo(): pass")
+
+            worker = PyWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+            assert result["files_found"] >= 3
+
+    def test_run_with_nonexistent_path(self):
+        """Test run with non-existent directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "nonexistent"
+
+            worker = PyWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is False
+            assert "error" in result
+
+    def test_run_excludes_venv(self):
+        """Test that venv directories are excluded."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            (repo_path / "main.py").write_text("print('hello')")
+
+            venv_dir = repo_path / ".venv"
+            venv_dir.mkdir()
+            (venv_dir / "script.py").write_text("print('venv')")
+
+            worker = PyWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+            py_files = result["py_files"]
+            assert all(".venv" not in f for f in py_files)

--- a/tests/test_pytest_worker.py
+++ b/tests/test_pytest_worker.py
@@ -1,0 +1,53 @@
+"""Tests for PytestWorker."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from auto_slopp.workers.pytest_worker import PytestWorker
+
+
+class TestPytestWorker:
+    """Tests for PytestWorker."""
+
+    def test_initialization(self):
+        """Test worker initialization."""
+        worker = PytestWorker()
+        assert worker.file_pattern == "test_*.py"
+
+    def test_run_with_existing_path(self):
+        """Test run with existing directory containing test files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            (repo_path / "test_example.py").write_text("def test_one(): pass\ndef test_two(): pass")
+            (repo_path / "example_test.py").write_text("def test_three(): pass")
+            (repo_path / "regular.py").write_text("def foo(): pass")
+
+            worker = PytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+            assert result["files_found"] >= 2
+
+    def test_run_with_nonexistent_path(self):
+        """Test run with non-existent directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "nonexistent"
+
+            worker = PytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is False
+            assert "error" in result
+
+    def test_run_empty_directory(self):
+        """Test run with empty directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            worker = PytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+            assert result["files_found"] == 0

--- a/tests/test_underscore_pytest_worker.py
+++ b/tests/test_underscore_pytest_worker.py
@@ -1,0 +1,51 @@
+"""Tests for UnderscorePytestWorker."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from auto_slopp.workers.underscore_pytest_worker import UnderscorePytestWorker
+
+
+class TestUnderscorePytestWorker:
+    """Tests for UnderscorePytestWorker."""
+
+    def test_initialization(self):
+        """Test worker initialization."""
+        worker = UnderscorePytestWorker()
+        assert worker.file_pattern == "_pytest*"
+
+    def test_run_with_existing_path(self):
+        """Test run with existing directory containing _pytest files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            (repo_path / "_pytest_example.py").write_text("# pytest config")
+            (repo_path / "conftest.py").write_text("import pytest")
+
+            worker = UnderscorePytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+
+    def test_run_with_nonexistent_path(self):
+        """Test run with non-existent directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "nonexistent"
+
+            worker = UnderscorePytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is False
+            assert "error" in result
+
+    def test_run_empty_directory(self):
+        """Test run with empty directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+
+            worker = UnderscorePytestWorker()
+            result = worker.run(repo_path, repo_path)
+
+            assert result["success"] is True
+            assert result["files_found"] == 0


### PR DESCRIPTION
## Summary
- Add PyWorker for scanning and handling Python (.py) files in repositories
- Add PytestWorker for scanning pytest test files (test_*.py, *_test.py)
- Add UnderscorePytestWorker for scanning files matching _pytest* pattern
- Add corresponding unit tests for all new workers