### PR TITLE
Add nodeenv console script entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,19 @@ heartbeat = HeartbeatWorker(message="Custom service is running")
 # Returns: timestamp, message, path information
 ```
 
+### NodeenvWorker
+Creates isolated Node.js virtual environments similar to Python's virtualenv.
+```python
+from auto_slopp.workers import NodeenvWorker
+
+# Create environment with latest LTS Node.js
+nodeenv = NodeenvWorker()
+# Returns: environment info, node/npm versions, activation scripts
+
+# Create environment with specific Node.js version
+nodeenv = NodeenvWorker(node_version="18.17.0", env_name="my-node-env")
+```
+
 ## API Reference
 
 ### Worker Base Class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ packages = ["src/auto_slopp"]
 
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
+nodeenv = "auto_slopp.nodeenv:main"
 
 [tool.black]
 line-length = 120

--- a/src/auto_slopp/nodeenv.py
+++ b/src/auto_slopp/nodeenv.py
@@ -1,0 +1,88 @@
+"""Console script entry point for nodeenv."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from auto_slopp.workers.nodeenv_worker import NodeenvWorker
+
+
+def main() -> int:
+    """Main entry point for the nodeenv console script.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure)
+    """
+    parser = argparse.ArgumentParser(description="Create Node.js virtual environments")
+    parser.add_argument(
+        "--node-version",
+        type=str,
+        help="Specific Node.js version to install (e.g., '18.17.0')",
+    )
+    parser.add_argument(
+        "--npm-version",
+        type=str,
+        help="Specific npm version to install (e.g., '9.6.7')",
+    )
+    parser.add_argument(
+        "--env-name",
+        type=str,
+        default="nodeenv",
+        help="Name for the virtual environment (default: nodeenv)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force recreation of existing environment",
+    )
+    parser.add_argument(
+        "--repo-path",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository directory path",
+    )
+    parser.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Output result as JSON",
+    )
+
+    args = parser.parse_args()
+
+    worker = NodeenvWorker(
+        node_version=args.node_version,
+        npm_version=args.npm_version,
+        env_name=args.env_name,
+        force_recreate=args.force,
+    )
+
+    task_path = Path.cwd() / args.env_name
+
+    try:
+        result = worker.run(args.repo_path, task_path)
+
+        if args.output_json:
+            print(json.dumps(result, indent=2))
+        else:
+            if result.get("success"):
+                print(f"Node.js environment created successfully at: {result.get('env_dir')}")
+                print(f"Node version: {result.get('node_version')}")
+                if result.get("node_installed", {}).get("npm_version"):
+                    print(f"npm version: {result.get('node_installed', {}).get('npm_version')}")
+            else:
+                print(
+                    f"Failed to create environment: {result.get('error')}",
+                    file=sys.stderr,
+                )
+                return 1
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -5,11 +5,13 @@ This package contains all worker implementations organized by functionality:
 """
 
 # Import all workers to make them available for discovery
+from auto_slopp.workers.nodeenv_worker import NodeenvWorker
 from auto_slopp.workers.renovate_test_worker import RenovateTestWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 from auto_slopp.workers.task_processor_worker import TaskProcessorWorker
 
 __all__ = [
+    "NodeenvWorker",
     "RenovateTestWorker",
     "StaleBranchCleanupWorker",
     "TaskProcessorWorker",

--- a/src/auto_slopp/workers/nodeenv_worker.py
+++ b/src/auto_slopp/workers/nodeenv_worker.py
@@ -1,0 +1,384 @@
+"""Node.js virtual environment worker for auto-slopp automation system.
+
+This worker creates Node.js virtual environments similar to Python's virtualenv,
+allowing for isolated Node.js and npm package management per project.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from auto_slopp.worker import Worker
+
+
+class NodeenvWorker(Worker):
+    """Worker for creating and managing Node.js virtual environments.
+
+    This worker provides functionality to:
+    1. Create isolated Node.js environments
+    2. Install specific Node.js versions
+    3. Manage npm packages in isolation
+    4. Provide activation/deactivation scripts
+    """
+
+    def __init__(
+        self,
+        node_version: Optional[str] = None,
+        npm_version: Optional[str] = None,
+        env_name: Optional[str] = None,
+        force_recreate: bool = False,
+    ):
+        """Initialize the NodeenvWorker.
+
+        Args:
+            node_version: Specific Node.js version to install (e.g., "18.17.0")
+            npm_version: Specific npm version to install (e.g., "9.6.7")
+            env_name: Name for the virtual environment (defaults to "nodeenv")
+            force_recreate: If True, recreate existing environment
+        """
+        self.node_version = node_version
+        self.npm_version = npm_version
+        self.env_name = env_name or "nodeenv"
+        self.force_recreate = force_recreate
+        self.logger = logging.getLogger("auto_slopp.workers.NodeenvWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the Node.js virtual environment creation.
+
+        Args:
+            repo_path: Path to the repository directory
+            task_path: Path to the task directory or file
+
+        Returns:
+            Dictionary containing execution results and environment info
+        """
+        import time
+
+        start_time = time.time()
+        self.logger.info(f"NodeenvWorker starting with repo_path: {repo_path}")
+
+        env_dir = self._get_env_directory(repo_path, task_path)
+
+        result = self._create_node_environment(env_dir)
+        result["execution_time"] = time.time() - start_time
+        result["timestamp"] = start_time
+        result["repo_path"] = str(repo_path)
+        result["task_path"] = str(task_path)
+        result["worker_name"] = "NodeenvWorker"
+
+        return result
+
+    def _get_env_directory(self, repo_path: Path, task_path: Path) -> Path:
+        """Determine the environment directory path.
+
+        Args:
+            repo_path: Repository path
+            task_path: Task path
+
+        Returns:
+            Path where the node environment should be created
+        """
+        base_path = task_path if task_path.is_dir() else repo_path
+        return base_path / self.env_name
+
+    def _create_node_environment(self, env_dir: Path) -> Dict[str, Any]:
+        """Create the Node.js virtual environment.
+
+        Args:
+            env_dir: Directory where environment should be created
+
+        Returns:
+            Dictionary with creation results
+        """
+        result = {
+            "success": False,
+            "env_dir": str(env_dir),
+            "node_version": self.node_version,
+            "npm_version": self.npm_version,
+            "error": None,
+            "messages": [],
+        }
+
+        try:
+            if env_dir.exists():
+                if self.force_recreate:
+                    self.logger.info(f"Removing existing environment: {env_dir}")
+                    shutil.rmtree(env_dir)
+                    result["messages"].append(f"Removed existing environment: {env_dir}")
+                else:
+                    result["success"] = True
+                    result["messages"].append(f"Environment already exists: {env_dir}")
+                    return result
+
+            env_dir.mkdir(parents=True, exist_ok=True)
+            self.logger.info(f"Creating Node.js environment in: {env_dir}")
+
+            node_version = self.node_version or self._get_latest_lts_version()
+            if not node_version:
+                raise RuntimeError("Could not determine Node.js version to install")
+
+            result["node_version"] = node_version
+
+            node_info = self._install_nodejs(env_dir, node_version)
+            result["node_installed"] = node_info
+
+            self._create_activation_scripts(env_dir)
+            result["messages"].append("Created activation scripts")
+
+            test_result = self._test_environment(env_dir)
+            result["test_result"] = test_result
+
+            result["success"] = True
+            result["messages"].append(f"Successfully created Node.js environment: {env_dir}")
+
+        except Exception as e:
+            result["error"] = str(e)
+            result["messages"].append(f"Failed to create environment: {e}")
+            self.logger.error(f"Failed to create Node.js environment: {e}")
+
+        return result
+
+    def _get_latest_lts_version(self) -> Optional[str]:
+        """Get the latest LTS Node.js version from Node.js API.
+
+        Returns:
+            Latest LTS version string or None if failed
+        """
+        try:
+            with urllib.request.urlopen("https://nodejs.org/dist/index.json", timeout=10) as response:  # nosec B310
+                data = json.loads(response.read().decode())
+
+                for release in data:
+                    if release.get("lts") and not release.get("security"):
+                        version = release["version"].lstrip("v")
+                        self.logger.info(f"Using latest LTS Node.js version: {version}")
+                        return version
+
+        except Exception as e:
+            self.logger.warning(f"Failed to fetch latest LTS version: {e}")
+
+        return "18.17.0"
+
+    def _install_nodejs(self, env_dir: Path, version: str) -> Dict[str, Any]:
+        """Install Node.js in the environment directory.
+
+        Args:
+            env_dir: Environment directory
+            version: Node.js version to install
+
+        Returns:
+            Dictionary with installation info
+        """
+        self.logger.info(f"Installing Node.js {version}")
+
+        bin_dir = env_dir / "bin"
+        bin_dir.mkdir(exist_ok=True)
+
+        platform = self._detect_platform()
+        arch = self._detect_architecture()
+
+        filename = f"node-v{version}-{platform}-{arch}.tar.gz"
+        download_url = f"https://nodejs.org/dist/v{version}/{filename}"
+
+        temp_dir = Path(tempfile.mkdtemp())
+        try:
+            archive_path = temp_dir / filename
+            self.logger.info(f"Downloading Node.js from: {download_url}")
+            urllib.request.urlretrieve(download_url, archive_path)  # nosec B310
+
+            extracted_dir = temp_dir / f"node-v{version}-{platform}-{arch}"
+            shutil.unpack_archive(archive_path, temp_dir)
+
+            node_source_dir = extracted_dir / "bin"
+            for file_path in node_source_dir.glob("*"):
+                shutil.copy2(file_path, bin_dir)
+
+            lib_dir = env_dir / "lib"
+            lib_dir.mkdir(exist_ok=True)
+            shutil.copytree(extracted_dir / "lib" / "node_modules", lib_dir / "node_modules")
+
+            include_dir = env_dir / "include"
+            include_dir.mkdir(exist_ok=True)
+            shutil.copytree(extracted_dir / "include" / "node", include_dir / "node")
+
+            share_dir = env_dir / "share"
+            share_dir.mkdir(exist_ok=True)
+            shutil.copytree(extracted_dir / "share" / "man", share_dir / "man")
+
+            return {
+                "version": version,
+                "platform": platform,
+                "arch": arch,
+                "bin_dir": str(bin_dir),
+                "success": True,
+            }
+
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _detect_platform(self) -> str:
+        """Detect the current platform for Node.js binaries.
+
+        Returns:
+            Platform string for Node.js downloads
+        """
+        system = sys.platform.lower()
+        if system == "darwin":
+            return "darwin"
+        elif system == "linux":
+            return "linux"
+        elif system == "win32":
+            return "win"
+        else:
+            return "linux"
+
+    def _detect_architecture(self) -> str:
+        """Detect the current architecture for Node.js binaries.
+
+        Returns:
+            Architecture string for Node.js downloads
+        """
+        machine = os.uname().machine.lower() if hasattr(os, "uname") else "x64"
+
+        if machine in ("x86_64", "amd64"):
+            return "x64"
+        elif machine in ("aarch64", "arm64"):
+            return "arm64"
+        elif machine.startswith("arm"):
+            return "armv7l"
+        else:
+            return "x64"
+
+    def _create_activation_scripts(self, env_dir: Path) -> None:
+        """Create activation scripts for the environment.
+
+        Args:
+            env_dir: Environment directory
+        """
+        bin_dir = env_dir / "bin"
+
+        activate_script = env_dir / "bin" / "activate"
+        with activate_script.open("w") as f:
+            f.write(f"""# Node.js virtual environment activation script
+# Usage: source {env_dir}/bin/activate
+
+_OLD_NODE_PATH="$PATH"
+
+export PATH="{bin_dir}:$PATH"
+
+export NODE_PATH="{env_dir}/lib/node_modules"
+
+export NODE_ENV_ACTIVE="{env_dir}"
+
+deactivate () {{
+    export PATH="$_OLD_NODE_PATH"
+
+    unset NODE_PATH
+    unset NODE_ENV_ACTIVE
+    unset _OLD_NODE_PATH
+
+    if [ -n "$_OLD_NODE_PS1" ]; then
+        export PS1="$_OLD_NODE_PS1"
+        unset _OLD_NODE_PS1
+    fi
+
+    echo "Node.js virtual environment deactivated"
+}}
+
+_OLD_NODE_PS1="$PS1"
+export PS1="(nodeenv) $PS1"
+
+echo "Node.js virtual environment activated"
+echo "Node.js version: $(node --version)"
+echo "npm version: $(npm --version)"
+""")
+
+        activate_script.chmod(0o755)
+
+        activate_bat = env_dir / "bin" / "activate.bat"
+        with activate_bat.open("w") as f:
+            f.write(f"""@echo off
+REM Node.js virtual environment activation script for Windows
+REM Usage: {env_dir}\\bin\\activate.bat
+
+set _OLD_NODE_PATH=%PATH%
+set PATH={bin_dir};%PATH%
+set NODE_PATH={env_dir}\\lib\\node_modules
+set NODE_ENV_ACTIVE={env_dir}
+
+echo Node.js virtual environment activated
+node --version
+npm --version
+""")
+
+        activate_ps1 = env_dir / "bin" / "activate.ps1"
+        with activate_ps1.open("w") as f:
+            f.write(f"""# Node.js virtual environment activation script for PowerShell
+# Usage: . {env_dir}\\bin\\activate.ps1
+
+$env:_OLD_NODE_PATH = $env:PATH
+$env:PATH = "{bin_dir};" + $env:PATH
+$env:NODE_PATH = "{env_dir}\\lib\\node_modules"
+$env:NODE_ENV_ACTIVE = "{env_dir}"
+
+Write-Host "Node.js virtual environment activated"
+node --version
+npm --version
+""")
+
+        for script in [activate_script, activate_bat, activate_ps1]:
+            script.chmod(0o755)
+
+    def _test_environment(self, env_dir: Path) -> Dict[str, Any]:
+        """Test the created Node.js environment.
+
+        Args:
+            env_dir: Environment directory to test
+
+        Returns:
+            Dictionary with test results
+        """
+        test_result = {"success": False, "node_version": None, "npm_version": None}
+
+        try:
+            bin_dir = env_dir / "bin"
+            node_exe = bin_dir / "node"
+            npm_exe = bin_dir / "npm"
+
+            if not node_exe.exists():
+                raise RuntimeError("Node.js executable not found")
+
+            result = subprocess.run(
+                [str(node_exe), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                test_result["node_version"] = result.stdout.strip()
+            else:
+                raise RuntimeError(f"Node.js version check failed: {result.stderr}")
+
+            if npm_exe.exists():
+                result = subprocess.run(
+                    [str(npm_exe), "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    test_result["npm_version"] = result.stdout.strip()
+
+            test_result["success"] = True
+
+        except Exception as e:
+            test_result["error"] = str(e)
+
+        return test_result

--- a/tests/test_nodeenv_worker.py
+++ b/tests/test_nodeenv_worker.py
@@ -1,0 +1,225 @@
+"""Tests for the NodeenvWorker."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from auto_slopp.workers.nodeenv_worker import NodeenvWorker
+
+
+class TestNodeenvWorker(unittest.TestCase):
+    """Test cases for NodeenvWorker."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.worker = NodeenvWorker(
+            node_version="18.17.0",
+            env_name="test-nodeenv",
+            force_recreate=True,
+        )
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.repo_path = self.temp_dir / "test-repo"
+        self.repo_path.mkdir()
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init(self):
+        """Test worker initialization."""
+        worker = NodeenvWorker()
+        self.assertIsNone(worker.node_version)
+        self.assertIsNone(worker.npm_version)
+        self.assertEqual(worker.env_name, "nodeenv")
+        self.assertFalse(worker.force_recreate)
+
+        worker = NodeenvWorker(
+            node_version="18.0.0",
+            npm_version="8.0.0",
+            env_name="custom-env",
+            force_recreate=True,
+        )
+        self.assertEqual(worker.node_version, "18.0.0")
+        self.assertEqual(worker.npm_version, "8.0.0")
+        self.assertEqual(worker.env_name, "custom-env")
+        self.assertTrue(worker.force_recreate)
+
+    def test_get_env_directory_with_task_path(self):
+        """Test environment directory resolution with task path."""
+        task_path = self.temp_dir / "task"
+        task_path.mkdir()
+
+        env_dir = self.worker._get_env_directory(self.repo_path, task_path)
+        self.assertEqual(env_dir, task_path / self.worker.env_name)
+
+    def test_get_env_directory_with_file_task_path(self):
+        """Test environment directory resolution with file task path."""
+        task_file = self.temp_dir / "task.txt"
+        task_file.write_text("test")
+
+        env_dir = self.worker._get_env_directory(self.repo_path, task_file)
+        self.assertEqual(env_dir, self.repo_path / self.worker.env_name)
+
+    def test_detect_platform(self):
+        """Test platform detection."""
+        platform = self.worker._detect_platform()
+        self.assertIn(platform, ["darwin", "linux", "win"])
+
+    def test_detect_architecture(self):
+        """Test architecture detection."""
+        arch = self.worker._detect_architecture()
+        self.assertIn(arch, ["x64", "arm64", "armv7l"])
+
+    @patch("auto_slopp.workers.nodeenv_worker.urllib.request.urlopen")
+    def test_get_latest_lts_version_success(self, mock_urlopen):
+        """Test successful LTS version fetch."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"""
+        [
+            {"version": "v20.5.0", "lts": false},
+            {"version": "v18.17.0", "lts": "Hydrogen", "security": false},
+            {"version": "v16.20.1", "lts": "Gallium"}
+        ]
+        """
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = self.worker._get_latest_lts_version()
+        self.assertEqual(version, "18.17.0")
+
+    @patch("auto_slopp.workers.nodeenv_worker.urllib.request.urlopen")
+    def test_get_latest_lts_version_failure(self, mock_urlopen):
+        """Test LTS version fetch failure fallback."""
+        mock_urlopen.side_effect = Exception("Network error")
+
+        version = self.worker._get_latest_lts_version()
+        self.assertEqual(version, "18.17.0")
+
+    def test_create_activation_scripts(self):
+        """Test creation of activation scripts."""
+        env_dir = self.temp_dir / "test-env"
+        env_dir.mkdir()
+        (env_dir / "bin").mkdir()
+
+        self.worker._create_activation_scripts(env_dir)
+
+        activate_script = env_dir / "bin" / "activate"
+        self.assertTrue(activate_script.exists())
+        content = activate_script.read_text()
+        self.assertIn("source", content)
+        self.assertIn("deactivate ()", content)
+
+        activate_bat = env_dir / "bin" / "activate.bat"
+        self.assertTrue(activate_bat.exists())
+
+        activate_ps1 = env_dir / "bin" / "activate.ps1"
+        self.assertTrue(activate_ps1.exists())
+
+    @patch.object(NodeenvWorker, "_install_nodejs")
+    @patch.object(NodeenvWorker, "_create_activation_scripts")
+    @patch.object(NodeenvWorker, "_test_environment")
+    @patch.object(NodeenvWorker, "_get_latest_lts_version")
+    def test_create_node_environment_success(self, mock_lts, mock_test, mock_scripts, mock_install):
+        """Test successful environment creation."""
+        mock_lts.return_value = "18.17.0"
+        mock_install.return_value = {"success": True, "version": "18.17.0"}
+        mock_test.return_value = {"success": True, "node_version": "v18.17.0"}
+
+        env_dir = self.repo_path / "nodeenv"
+        result = self.worker._create_node_environment(env_dir)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["env_dir"], str(env_dir))
+        self.assertEqual(result["node_version"], "18.17.0")
+        mock_install.assert_called_once()
+        mock_scripts.assert_called_once()
+        mock_test.assert_called_once()
+
+    def test_create_node_environment_existing(self):
+        """Test environment creation when directory exists."""
+        worker = NodeenvWorker(force_recreate=False)
+        env_dir = self.repo_path / "nodeenv"
+        env_dir.mkdir()
+
+        result = worker._create_node_environment(env_dir)
+
+        self.assertTrue(result["success"])
+        self.assertIn("already exists", result["messages"][-1])
+
+    def test_create_node_environment_force_recreate(self):
+        """Test environment recreation with force flag."""
+        worker = NodeenvWorker(force_recreate=True)
+
+        env_dir = self.repo_path / "nodeenv"
+        env_dir.mkdir()
+
+        with patch.object(worker, "_install_nodejs") as mock_install:
+            with patch.object(worker, "_create_activation_scripts"):
+                with patch.object(worker, "_test_environment") as mock_test:
+                    with patch.object(worker, "_get_latest_lts_version") as mock_lts:
+                        mock_lts.return_value = "18.17.0"
+                        mock_install.return_value = {"success": True}
+                        mock_test.return_value = {"success": True}
+
+                        result = worker._create_node_environment(env_dir)
+
+                        self.assertTrue(result["success"])
+                        mock_install.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_test_environment_success(self, mock_subprocess):
+        """Test successful environment testing."""
+        env_dir = self.temp_dir / "test-env"
+        env_dir.mkdir()
+        bin_dir = env_dir / "bin"
+        bin_dir.mkdir()
+
+        (bin_dir / "node").touch()
+        (bin_dir / "npm").touch()
+
+        mock_subprocess.side_effect = [
+            MagicMock(returncode=0, stdout="v18.17.0"),
+            MagicMock(returncode=0, stdout="9.6.7"),
+        ]
+
+        result = self.worker._test_environment(env_dir)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["node_version"], "v18.17.0")
+        self.assertEqual(result["npm_version"], "9.6.7")
+
+    @patch("subprocess.run")
+    def test_test_environment_node_missing(self, mock_subprocess):
+        """Test environment testing with missing node executable."""
+        env_dir = self.temp_dir / "test-env"
+        env_dir.mkdir()
+        bin_dir = env_dir / "bin"
+        bin_dir.mkdir()
+
+        result = self.worker._test_environment(env_dir)
+
+        self.assertFalse(result["success"])
+        self.assertIn("not found", result["error"])
+
+    @patch("subprocess.run")
+    def test_test_environment_node_failure(self, mock_subprocess):
+        """Test environment testing with node execution failure."""
+        env_dir = self.temp_dir / "test-env"
+        env_dir.mkdir()
+        bin_dir = env_dir / "bin"
+        bin_dir.mkdir()
+
+        (bin_dir / "node").touch()
+
+        mock_subprocess.return_value = MagicMock(returncode=1, stderr="Command failed")
+
+        result = self.worker._test_environment(env_dir)
+
+        self.assertFalse(result["success"])
+        self.assertIn("failed", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `nodeenv` console script entry point to pyproject.toml
- Create nodeenv.py module with CLI interface for Node.js virtual environment creation
- Cherry-pick NodeenvWorker from existing feature branch

## Changes
- Add `nodeenv = "auto_slopp.nodeenv:main"` to [project.scripts]
- Create src/auto_slopp/nodeenv.py with argparse CLI
- Cherry-pick nodeenv_worker.py and tests from ai/nodeenv branch

## Testing
- `make test` passes successfully (130 tests)