### PR TITLE
Add dotenv CLI console script entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ packages = ["src/auto_slopp"]
 
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
+dotenv = "dotenv.__main__:cli"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
This PR adds the dotenv CLI entry point to pyproject.toml, allowing users to run  command after installing the package.