### PR TITLE
Add identify package dependency and console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "httpx>=0.25.0",
     "python-dotenv>=1.0.0",
+    "identify>=2.6.0",
 ]
 
 [project.optional-dependencies]
@@ -34,6 +35,9 @@ packages = ["src/auto_slopp"]
 
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
+
+[console_scripts]
+identify = "identify.__main__:cli"
 
 [tool.black]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "identify" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -86,6 +87,7 @@ requires-dist = [
     { name = "flake8-docstrings", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "flake8-import-order", marker = "extra == 'dev'", specifier = ">=0.18.2" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "identify", specifier = ">=2.6.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- Add `identify>=2.6.0` package as a dependency for file identification capabilities
- Add `identify-cli` console script entry point for CLI usage

This implementation adds the pre-commit `identify` package which provides file identification library for Python. The package can identify file types based on extensions, shebangs, and file content.