### PR TITLE
Add isort console scripts and distutils commands

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[metadata]
+name = my_test_package
+version = 0.1.0
+description = My test package
+author = Test Author
+author_email = test@example.com
+
+[options]
+packages = find:
+python_requires = >=3.8
+
+[console_scripts]
+isort = isort.main:main
+isort-identify-imports = isort.main:identify_imports_main
+
+[distutils.commands]
+isort = isort.setuptools_commands:ISortCommand


### PR DESCRIPTION
## Summary
- Added isort entry points in setup.cfg:
  - `isort` console script pointing to `isort.main:main`
  - `isort-identify-imports` console script pointing to `isort.main:identify_imports_main`
  - `isort` distutils command pointing to `isort.setuptools_commands:ISortCommand`
- Tests pass successfully