### PR TITLE
Add setup.cfg analyzer worker for popular Python packages

### DIFF
--- a/src/auto_slopp/utils/setup_cfg_analyzer.py
+++ b/src/auto_slopp/utils/setup_cfg_analyzer.py
@@ -1,0 +1,226 @@
+"""Utility for fetching and parsing setup.cfg files from popular Python packages."""
+
+import configparser
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SetupCfgInfo:
+    """Parsed information from a setup.cfg file."""
+
+    package_name: str
+    url: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    options: Dict[str, Any] = field(default_factory=dict)
+    entry_points: Dict[str, List[str]] = field(default_factory=dict)
+    raw_content: str = ""
+    error: Optional[str] = None
+
+
+POPULAR_PACKAGES_SETUP_CFG = [
+    (
+        "setuptools",
+        "https://github.com/pypa/setuptools/raw/52c990172fec37766b3566679724aa8bf70ae06d/setup.cfg",
+    ),
+    (
+        "wheel",
+        "https://github.com/pypa/wheel/raw/0acd203cd896afec7f715aa2ff5980a403459a3b/setup.cfg",
+    ),
+    (
+        "importlib_metadata",
+        "https://github.com/python/importlib_metadata/raw/2f05392ca980952a6960d82b2f2d2ea10aa53239/setup.cfg",
+    ),
+    (
+        "jaraco.skeleton",
+        "https://github.com/jaraco/skeleton/raw/d9008b5c510cd6969127a6a2ab6f832edddef296/setup.cfg",
+    ),
+    (
+        "jaraco.zipp",
+        "https://github.com/jaraco/zipp/raw/700d3a96390e970b6b962823bfea78b4f7e1c537/setup.cfg",
+    ),
+    (
+        "jinja",
+        "https://github.com/pallets/jinja/raw/7d72eb7fefb7dce065193967f31f805180508448/setup.cfg",
+    ),
+    (
+        "cachetools",
+        "https://github.com/tkem/cachetools/raw/2fd87a94b8d3861d80e9e4236cd480bfdd21c90d/setup.cfg",
+    ),
+    (
+        "aiohttp",
+        "https://github.com/aio-libs/aiohttp/raw/5e0e6b7080f2408d5f1dd544c0e1cf88378b7b10/setup.cfg",
+    ),
+    (
+        "flask",
+        "https://github.com/pallets/flask/raw/9486b6cf57bd6a8a261f67091aca8ca78eeec1e3/setup.cfg",
+    ),
+    (
+        "click",
+        "https://github.com/pallets/click/raw/6411f425fae545f42795665af4162006b36c5e4a/setup.cfg",
+    ),
+    (
+        "sqlalchemy",
+        "https://github.com/sqlalchemy/sqlalchemy/raw/533f5718904b620be8d63f2474229945d6f8ba5d/setup.cfg",
+    ),
+    (
+        "pluggy",
+        "https://github.com/pytest-dev/pluggy/raw/461ef63291d13589c4e21aa182cd1529257e9a0a/setup.cfg",
+    ),
+    (
+        "pytest",
+        "https://github.com/pytest-dev/pytest/raw/c7be96dae487edbd2f55b561b31b68afac1dabe6/setup.cfg",
+    ),
+    (
+        "platformdirs",
+        "https://github.com/platformdirs/platformdirs/raw/7b7852128dd6f07511b618d6edea35046bd0c6ff/setup.cfg",
+    ),
+    (
+        "pandas",
+        "https://github.com/pandas-dev/pandas/raw/bc17343f934a33dc231c8c74be95d8365537c376/setup.cfg",
+    ),
+    (
+        "django",
+        "https://github.com/django/django/raw/4e249d11a6e56ca8feb4b055b681cec457ef3a3d/setup.cfg",
+    ),
+    (
+        "pyscaffold",
+        "https://github.com/pyscaffold/pyscaffold/raw/de7aa5dc059fbd04307419c667cc4961bc9df4b8/setup.cfg",
+    ),
+    (
+        "virtualenv",
+        "https://github.com/pypa/virtualenv/raw/f92eda6e3da26a4d28c2663ffb85c4960bdb990c/setup.cfg",
+    ),
+]
+
+
+def fetch_setup_cfg(url: str) -> Optional[str]:
+    """Fetch setup.cfg content from a URL.
+
+    Args:
+        url: URL to fetch the setup.cfg from
+
+    Returns:
+        Content of the setup.cfg file or None if fetch failed
+    """
+    try:
+        with urlopen(url, timeout=30) as response:
+            return response.read().decode("utf-8")
+    except (HTTPError, URLError) as e:
+        logger.warning(f"Failed to fetch {url}: {e}")
+        return None
+
+
+def parse_setup_cfg(content: str) -> configparser.ConfigParser:
+    """Parse setup.cfg content into a ConfigParser.
+
+    Args:
+        content: Raw setup.cfg content
+
+    Returns:
+        Parsed ConfigParser object
+    """
+    parser = configparser.ConfigParser()
+    parser.read_string(content)
+    return parser
+
+
+def extract_metadata(parser: configparser.ConfigParser) -> Dict[str, Any]:
+    """Extract metadata section from parsed setup.cfg.
+
+    Args:
+        parser: Parsed ConfigParser
+
+    Returns:
+        Dictionary of metadata key-value pairs
+    """
+    metadata = {}
+    if parser.has_section("metadata"):
+        for key, value in parser.items("metadata"):
+            metadata[key] = value
+    return metadata
+
+
+def extract_options(parser: configparser.ConfigParser) -> Dict[str, Any]:
+    """Extract options section from parsed setup.cfg.
+
+    Args:
+        parser: Parsed ConfigParser
+
+    Returns:
+        Dictionary of options key-value pairs
+    """
+    options = {}
+    if parser.has_section("options"):
+        for key, value in parser.items("options"):
+            options[key] = value
+    return options
+
+
+def extract_entry_points(parser: configparser.ConfigParser) -> Dict[str, List[str]]:
+    """Extract entry points from parsed setup.cfg.
+
+    Args:
+        parser: Parsed ConfigParser
+
+    Returns:
+        Dictionary of entry point sections and their values
+    """
+    entry_points = {}
+    for section in parser.sections():
+        if section.startswith("options.entry_points") or "entry_points" in section:
+            entries = []
+            for key, value in parser.items(section):
+                if value:
+                    entries.append(f"{key} = {value}")
+            if entries:
+                entry_points[section] = entries
+    return entry_points
+
+
+def fetch_and_parse_setup_cfg(url: str, package_name: str) -> SetupCfgInfo:
+    """Fetch and parse a setup.cfg file from a URL.
+
+    Args:
+        url: URL to fetch the setup.cfg from
+        package_name: Name of the package
+
+    Returns:
+        SetupCfgInfo object with parsed information
+    """
+    result = SetupCfgInfo(package_name=package_name, url=url)
+
+    content = fetch_setup_cfg(url)
+    if content is None:
+        result.error = "Failed to fetch setup.cfg"
+        return result
+
+    result.raw_content = content
+
+    try:
+        parser = parse_setup_cfg(content)
+        result.metadata = extract_metadata(parser)
+        result.options = extract_options(parser)
+        result.entry_points = extract_entry_points(parser)
+    except Exception as e:
+        result.error = f"Failed to parse setup.cfg: {e}"
+
+    return result
+
+
+def fetch_all_popular_packages_setup_cfg() -> List[SetupCfgInfo]:
+    """Fetch and parse setup.cfg from all popular packages.
+
+    Returns:
+        List of SetupCfgInfo objects for each package
+    """
+    results = []
+    for package_name, url in POPULAR_PACKAGES_SETUP_CFG:
+        info = fetch_and_parse_setup_cfg(url, package_name)
+        results.append(info)
+    return results

--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -6,11 +6,13 @@ This package contains all worker implementations organized by functionality:
 
 # Import all workers to make them available for discovery
 from auto_slopp.workers.renovate_test_worker import RenovateTestWorker
+from auto_slopp.workers.setup_cfg_analyzer_worker import SetupCfgAnalyzerWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 from auto_slopp.workers.task_processor_worker import TaskProcessorWorker
 
 __all__ = [
     "RenovateTestWorker",
+    "SetupCfgAnalyzerWorker",
     "StaleBranchCleanupWorker",
     "TaskProcessorWorker",
 ]

--- a/src/auto_slopp/workers/setup_cfg_analyzer_worker.py
+++ b/src/auto_slopp/workers/setup_cfg_analyzer_worker.py
@@ -1,0 +1,91 @@
+"""Worker for analyzing setup.cfg files from popular Python packages."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+from auto_slopp.utils.setup_cfg_analyzer import (
+    POPULAR_PACKAGES_SETUP_CFG,
+    fetch_all_popular_packages_setup_cfg,
+    fetch_and_parse_setup_cfg,
+)
+from auto_slopp.worker import Worker
+
+
+class SetupCfgAnalyzerWorker(Worker):
+    """Worker for analyzing setup.cfg files from popular Python packages.
+
+    This worker fetches and parses setup.cfg files from popular Python packages
+    to understand their configuration patterns, entry points, and metadata.
+    """
+
+    def __init__(self, package_filter: list[str] | None = None):
+        """Initialize the SetupCfgAnalyzerWorker.
+
+        Args:
+            package_filter: Optional list of package names to filter.
+                           If None, all packages are processed.
+        """
+        self.package_filter = package_filter
+        self.logger = logging.getLogger("auto_slopp.workers.SetupCfgAnalyzerWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the setup.cfg analysis.
+
+        Args:
+            repo_path: Path to repository (unused)
+            task_path: Path to task directory (unused)
+
+        Returns:
+            Dictionary containing analysis results
+        """
+        self.logger.info("Starting setup.cfg analysis for popular packages")
+
+        if self.package_filter:
+            packages_to_process = [
+                (name, url) for name, url in POPULAR_PACKAGES_SETUP_CFG if name in self.package_filter
+            ]
+        else:
+            packages_to_process = POPULAR_PACKAGES_SETUP_CFG
+
+        results = {
+            "worker_name": "SetupCfgAnalyzerWorker",
+            "packages_analyzed": 0,
+            "packages_succeeded": 0,
+            "packages_failed": 0,
+            "package_details": [],
+        }
+
+        for package_name, url in packages_to_process:
+            self.logger.info(f"Analyzing setup.cfg for {package_name}")
+            info = fetch_and_parse_setup_cfg(url, package_name)
+
+            results["packages_analyzed"] += 1
+
+            if info.error:
+                results["packages_failed"] += 1
+                self.logger.warning(f"Failed to analyze {package_name}: {info.error}")
+            else:
+                results["packages_succeeded"] += 1
+
+            results["package_details"].append(
+                {
+                    "name": package_name,
+                    "url": url,
+                    "has_metadata": bool(info.metadata),
+                    "has_options": bool(info.options),
+                    "has_entry_points": bool(info.entry_points),
+                    "metadata_keys": list(info.metadata.keys()) if info.metadata else [],
+                    "options_keys": list(info.options.keys()) if info.options else [],
+                    "entry_point_sections": list(info.entry_points.keys()) if info.entry_points else [],
+                    "error": info.error,
+                }
+            )
+
+        self.logger.info(
+            f"Analysis complete. Analyzed: {results['packages_analyzed']}, "
+            f"Succeeded: {results['packages_succeeded']}, "
+            f"Failed: {results['packages_failed']}"
+        )
+
+        return results

--- a/tests/test_setup_cfg_analyzer.py
+++ b/tests/test_setup_cfg_analyzer.py
@@ -1,0 +1,185 @@
+"""Tests for setup_cfg_analyzer utility and worker."""
+
+from unittest.mock import patch
+
+import pytest
+
+from auto_slopp.utils.setup_cfg_analyzer import (
+    POPULAR_PACKAGES_SETUP_CFG,
+    SetupCfgInfo,
+    extract_entry_points,
+    extract_metadata,
+    extract_options,
+    fetch_and_parse_setup_cfg,
+    fetch_setup_cfg,
+    parse_setup_cfg,
+)
+
+
+class TestFetchSetupCfg:
+    """Tests for fetch_setup_cfg function."""
+
+    @patch("auto_slopp.utils.setup_cfg_analyzer.urlopen")
+    def test_fetch_setup_cfg_success(self, mock_urlopen):
+        """Test successful fetch of setup.cfg."""
+        mock_response = b"[metadata]\nname = test-package\nversion = 1.0.0"
+        mock_context = mock_urlopen.return_value.__enter__.return_value
+        mock_context.read.return_value = mock_response
+
+        result = fetch_setup_cfg("https://example.com/setup.cfg")
+
+        assert result is not None
+        assert "metadata" in result
+
+    @patch("auto_slopp.utils.setup_cfg_analyzer.urlopen")
+    def test_fetch_setup_cfg_failure(self, mock_urlopen):
+        """Test failed fetch returns None."""
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("Connection failed")
+
+        result = fetch_setup_cfg("https://example.com/setup.cfg")
+
+        assert result is None
+
+
+class TestParseSetupCfg:
+    """Tests for parse_setup_cfg function."""
+
+    def test_parse_simple_setup_cfg(self):
+        """Test parsing a simple setup.cfg."""
+        content = """[metadata]
+name = test-package
+version = 1.0.0
+
+[options]
+packages = find
+"""
+        parser = parse_setup_cfg(content)
+
+        assert parser.has_section("metadata")
+        assert parser.has_section("options")
+        assert parser.get("metadata", "name") == "test-package"
+        assert parser.get("metadata", "version") == "1.0.0"
+
+
+class TestExtractMetadata:
+    """Tests for extract_metadata function."""
+
+    def test_extract_metadata_basic(self):
+        """Test extracting basic metadata."""
+        content = """[metadata]
+name = test-package
+author = Test Author
+version = 1.0.0
+"""
+        parser = parse_setup_cfg(content)
+        metadata = extract_metadata(parser)
+
+        assert metadata["name"] == "test-package"
+        assert metadata["author"] == "Test Author"
+        assert metadata["version"] == "1.0.0"
+
+    def test_extract_metadata_empty(self):
+        """Test extracting metadata from config without metadata section."""
+        content = """[options]
+packages = find
+"""
+        parser = parse_setup_cfg(content)
+        metadata = extract_metadata(parser)
+
+        assert metadata == {}
+
+
+class TestExtractOptions:
+    """Tests for extract_options function."""
+
+    def test_extract_options_basic(self):
+        """Test extracting basic options."""
+        content = """[options]
+packages = find
+python_requires = >=3.7
+"""
+        parser = parse_setup_cfg(content)
+        options = extract_options(parser)
+
+        assert options["packages"] == "find"
+        assert options["python_requires"] == ">=3.7"
+
+
+class TestExtractEntryPoints:
+    """Tests for extract_entry_points function."""
+
+    def test_extract_entry_points_console_scripts(self):
+        """Test extracting console_scripts entry points."""
+        content = """[options.entry_points]
+console_scripts =
+    mycmd = mypackage.cli:main
+"""
+        parser = parse_setup_cfg(content)
+        entry_points = extract_entry_points(parser)
+
+        assert "options.entry_points" in entry_points
+
+    def test_extract_entry_points_empty(self):
+        """Test extracting entry points when none exist."""
+        content = """[metadata]
+name = test-package
+"""
+        parser = parse_setup_cfg(content)
+        entry_points = extract_entry_points(parser)
+
+        assert entry_points == {}
+
+
+class TestSetupCfgInfo:
+    """Tests for SetupCfgInfo dataclass."""
+
+    def test_setup_cfg_info_creation(self):
+        """Test creating a SetupCfgInfo object."""
+        info = SetupCfgInfo(
+            package_name="test-package",
+            url="https://example.com/setup.cfg",
+            metadata={"name": "test"},
+            options={"packages": "find"},
+            entry_points={"console_scripts": ["test = main"]},
+        )
+
+        assert info.package_name == "test-package"
+        assert info.metadata == {"name": "test"}
+        assert info.options == {"packages": "find"}
+        assert info.entry_points == {"console_scripts": ["test = main"]}
+
+    def test_setup_cfg_info_with_error(self):
+        """Test SetupCfgInfo with error."""
+        info = SetupCfgInfo(
+            package_name="test-package",
+            url="https://example.com/setup.cfg",
+            error="Failed to fetch",
+        )
+
+        assert info.error == "Failed to fetch"
+
+
+class TestPopularPackagesList:
+    """Tests for POPULAR_PACKAGES_SETUP_CFG list."""
+
+    def test_popular_packages_not_empty(self):
+        """Test that popular packages list is not empty."""
+        assert len(POPULAR_PACKAGES_SETUP_CFG) > 0
+
+    def test_popular_packages_format(self):
+        """Test that popular packages have correct format."""
+        for package_name, url in POPULAR_PACKAGES_SETUP_CFG:
+            assert isinstance(package_name, str)
+            assert isinstance(url, str)
+            assert url.startswith("https://github.com/")
+            assert url.endswith("setup.cfg")
+
+    def test_expected_packages_present(self):
+        """Test that expected packages are in the list."""
+        package_names = [name for name, _ in POPULAR_PACKAGES_SETUP_CFG]
+
+        expected = ["setuptools", "wheel", "pytest", "flask", "django"]
+        for pkg in expected:
+            assert pkg in package_names


### PR DESCRIPTION
## Summary
- Add utility module to fetch and parse setup.cfg files from 18 popular Python packages (setuptools, wheel, pytest, flask, django, etc.)
- Add `SetupCfgAnalyzerWorker` that fetches and analyzes setup.cfg configuration from popular packages
- Add comprehensive tests for the new functionality

This implementation provides insight into how popular Python packages configure their metadata, entry points, and options.