### PR TITLE
Add pytest console script entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "httpx>=0.25.0",
     "python-dotenv>=1.0.0",
+    "pytest>=7.4.0",
 ]
 
 [project.optional-dependencies]
@@ -34,6 +35,8 @@ packages = ["src/auto_slopp"]
 
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
+"py.test" = "pytest:console_main"
+pytest = "pytest:console_main"
 
 [tool.black]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pytest" },
     { name = "python-dotenv" },
 ]
 
@@ -89,6 +90,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- Add pytest dependency to main dependencies
- Add py.test and pytest console script entry points to pyproject.toml
- These entry points allow running pytest via `py.test` or `pytest` command after package installation