### PR TITLE
Add dotenv console script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ packages = ["src/auto_slopp"]
 [project.scripts]
 auto-slopp = "auto_slopp.main:main"
 
+[console_scripts]
+dotenv = "dotenv.__main__:cli"
+
 [tool.black]
 line-length = 120
 target-version = ['py314']


### PR DESCRIPTION
This PR adds a console_scripts entry point for dotenv CLI, allowing users to run the dotenv command after installing the package.