### PR TITLE
Fix PRWorker git repository detection

### DIFF
--- a/src/auto_slopp/executor.py
+++ b/src/auto_slopp/executor.py
@@ -126,6 +126,7 @@ class Executor:
             "TaskProcessorWorker",
             "RenovateTestWorker",
             "StaleBranchCleanupWorker",
+            "PRWorker",
         }
 
         return worker_class.__name__ in workers_requiring_iteration
@@ -158,19 +159,25 @@ class Executor:
                 worker = self._instantiate_worker(worker_class)
 
                 # Map repo_task_path to corresponding subdirectory
-                repo_task_path = self.task_path / subdirectory.name if self.task_path else None
+                repo_task_path = (
+                    self.task_path / subdirectory.name if self.task_path else None
+                )
 
                 # Execute worker on single subdirectory
                 start_time = time.time()
                 result = worker.run(subdirectory, repo_task_path)
                 execution_time = time.time() - start_time
 
-                print(f"Worker {worker_class.__name__} on {subdirectory.name} completed in {execution_time:.2f}s")
+                print(
+                    f"Worker {worker_class.__name__} on {subdirectory.name} completed in {execution_time:.2f}s"
+                )
                 if result is not None:
                     print(f"Result: {result}")
 
             except Exception as e:
-                print(f"Error executing worker {worker_class.__name__} on {subdirectory.name}: {e}")
+                print(
+                    f"Error executing worker {worker_class.__name__} on {subdirectory.name}: {e}"
+                )
                 traceback.print_exc()
 
     def _execute_worker_single(self, worker_class: Type[Worker]) -> None:

--- a/src/auto_slopp/executor.py
+++ b/src/auto_slopp/executor.py
@@ -159,25 +159,19 @@ class Executor:
                 worker = self._instantiate_worker(worker_class)
 
                 # Map repo_task_path to corresponding subdirectory
-                repo_task_path = (
-                    self.task_path / subdirectory.name if self.task_path else None
-                )
+                repo_task_path = self.task_path / subdirectory.name if self.task_path else None
 
                 # Execute worker on single subdirectory
                 start_time = time.time()
                 result = worker.run(subdirectory, repo_task_path)
                 execution_time = time.time() - start_time
 
-                print(
-                    f"Worker {worker_class.__name__} on {subdirectory.name} completed in {execution_time:.2f}s"
-                )
+                print(f"Worker {worker_class.__name__} on {subdirectory.name} completed in {execution_time:.2f}s")
                 if result is not None:
                     print(f"Result: {result}")
 
             except Exception as e:
-                print(
-                    f"Error executing worker {worker_class.__name__} on {subdirectory.name}: {e}"
-                )
+                print(f"Error executing worker {worker_class.__name__} on {subdirectory.name}: {e}")
                 traceback.print_exc()
 
     def _execute_worker_single(self, worker_class: Type[Worker]) -> None:

--- a/src/auto_slopp/utils/repository_utils.py
+++ b/src/auto_slopp/utils/repository_utils.py
@@ -136,9 +136,7 @@ def validate_repository(repo_dir: Path) -> Dict[str, Any]:
     return result
 
 
-def discover_repositories(
-    repo_path: Path, validate: bool = True
-) -> List[Dict[str, Any]]:
+def discover_repositories(repo_path: Path, validate: bool = True) -> List[Dict[str, Any]]:
     """Discover all git repositories in the given path.
 
     Args:
@@ -219,9 +217,7 @@ def get_repository_status(repo_dir: Path) -> Dict[str, Any]:
 
         status = {
             "valid": True,
-            "current_branch": branch_result.stdout.strip()
-            if branch_result.returncode == 0
-            else None,
+            "current_branch": branch_result.stdout.strip() if branch_result.returncode == 0 else None,
             "is_clean": len(status_result.stdout.strip()) == 0,
             "changed_files": [],
             "ahead": 0,

--- a/src/auto_slopp/utils/repository_utils.py
+++ b/src/auto_slopp/utils/repository_utils.py
@@ -20,7 +20,12 @@ def is_git_repository(repo_dir: Path) -> bool:
     """
     try:
         git_dir = repo_dir / ".git"
-        return git_dir.exists() and git_dir.is_dir()
+        # Check for .git as a directory (normal repo) or as a file (worktree)
+        if git_dir.is_dir():
+            return True
+        if git_dir.is_file():
+            return True
+        return False
     except Exception:
         return False
 
@@ -131,7 +136,9 @@ def validate_repository(repo_dir: Path) -> Dict[str, Any]:
     return result
 
 
-def discover_repositories(repo_path: Path, validate: bool = True) -> List[Dict[str, Any]]:
+def discover_repositories(
+    repo_path: Path, validate: bool = True
+) -> List[Dict[str, Any]]:
     """Discover all git repositories in the given path.
 
     Args:
@@ -212,7 +219,9 @@ def get_repository_status(repo_dir: Path) -> Dict[str, Any]:
 
         status = {
             "valid": True,
-            "current_branch": branch_result.stdout.strip() if branch_result.returncode == 0 else None,
+            "current_branch": branch_result.stdout.strip()
+            if branch_result.returncode == 0
+            else None,
             "is_clean": len(status_result.stdout.strip()) == 0,
             "changed_files": [],
             "ahead": 0,


### PR DESCRIPTION
## Summary

- **Root Cause**: PRWorker was not in the `workers_requiring_iteration` set in the executor, causing it to receive the base repo path (containing multiple subdirectories) instead of individual git repositories.

- **Secondary Issue**: The `is_git_repository` function only checked for `.git` as a directory, not as a file (which is the case for git worktrees).

## Changes

1. **executor.py**: Added `PRWorker` to `workers_requiring_iteration` set so the executor passes individual repo directories to PRWorker instead of the base path.

2. **repository_utils.py**: Updated `is_git_repository` to handle both:
   - Normal repositories where `.git` is a directory
   - Git worktrees where `.git` is a file pointing to the actual git directory