### PR TITLE
fix: push task_repo changes to remote after processing

### DIFF
--- a/src/auto_slopp/utils/task_processing.py
+++ b/src/auto_slopp/utils/task_processing.py
@@ -120,18 +120,22 @@ def process_text_file(
 
         # Commit and push changes in task_repo_path
         if not dry_run:
-            # Commit the changes without pushing
-            commit_success, _ = commit_and_push_changes(
+            # Commit the changes and push to remote
+            commit_success, push_success = commit_and_push_changes(
                 task_repo_dir,
                 f"Process instruction file: {text_file.name}",
-                push_if_remote=False,
+                push_if_remote=True,
             )
 
             if not commit_success:
                 result["error"] = "Git commit operations failed"
                 return result
+
+            if push_success is False:
+                result["error"] = "Git push operations failed"
+                return result
         else:
-            logger.info(f"DRY RUN: Would commit changes for {text_file.name}")
+            logger.info(f"DRY RUN: Would commit and push changes for {text_file.name}")
             result["git_operations"] = True
 
         result["success"] = True


### PR DESCRIPTION
## Summary
- Fixes the issue where `task_repo` never gets updated because changes were committed locally but never pushed to the remote
- Changes `push_if_remote=False` to `push_if_remote=True` in `process_text_file` function
- Adds error handling for push failures

## Problem
The `task_repo` was never being updated because `commit_and_push_changes` was called with `push_if_remote=False`, which commits changes locally but never pushes them to the remote repository.

## Solution
- Changed `push_if_remote=False` to `push_if_remote=True` in the `process_text_file` function in `task_processing.py`
- Added error handling to check if the push operation failed