### PR TITLE
Add UpdatePRBranchesWorker to update open PR branches

### DIFF
--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -8,9 +8,11 @@ This package contains all worker implementations organized by functionality:
 from auto_slopp.workers.pr_worker import PRWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 from auto_slopp.workers.task_processor_worker import TaskProcessorWorker
+from auto_slopp.workers.update_pr_branches_worker import UpdatePRBranchesWorker
 
 __all__ = [
     "PRWorker",
     "StaleBranchCleanupWorker",
     "TaskProcessorWorker",
+    "UpdatePRBranchesWorker",
 ]

--- a/src/auto_slopp/workers/update_pr_branches_worker.py
+++ b/src/auto_slopp/workers/update_pr_branches_worker.py
@@ -1,0 +1,207 @@
+"""PR branch update worker for auto-slopp automation system.
+
+This worker iterates through all open PRs and updates each branch with the latest main.
+"""
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+from auto_slopp.utils.git_operations import checkout_branch_resilient
+from auto_slopp.utils.repository_utils import validate_repository
+from auto_slopp.worker import Worker
+
+
+class UpdatePRBranchesWorker(Worker):
+    """Worker for updating open PR branches with latest main."""
+
+    def __init__(self):
+        """Initialize UpdatePRBranchesWorker."""
+        self.logger = logging.getLogger("auto_slopp.workers.UpdatePRBranchesWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute PR branch update workflow for a single repository.
+
+        Args:
+            repo_path: Path to a single repository directory
+            task_path: Path to task directory or file (not used in this worker)
+
+        Returns:
+            Dictionary containing execution results and summary.
+        """
+        self.logger.info(f"UpdatePRBranchesWorker starting for {repo_path}")
+
+        if not repo_path.exists():
+            return {
+                "worker_name": "UpdatePRBranchesWorker",
+                "success": False,
+                "error": f"Repository path does not exist: {repo_path}",
+                "branches_updated": 0,
+            }
+
+        repo_info = validate_repository(repo_path)
+
+        results = {
+            "worker_name": "UpdatePRBranchesWorker",
+            "success": True,
+            "branches_updated": 0,
+            "branches_failed": 0,
+            "branch_results": [],
+        }
+
+        if not repo_info.get("valid", False):
+            self.logger.warning(
+                f"Repository is invalid: {repo_path.name} - {repo_info.get('errors', ['Unknown error'])}"
+            )
+            results["success"] = False
+            results["error"] = f"Invalid repository: {repo_info.get('errors', ['Unknown error'])}"
+            return results
+
+        pr_branches = self._get_open_pr_branches(repo_path)
+
+        if not pr_branches:
+            self.logger.info(f"No open PR branches found in {repo_path.name}")
+            return results
+
+        for branch in pr_branches:
+            self.logger.info(f"Updating branch {branch} in {repo_path.name}")
+
+            branch_result = {
+                "branch": branch,
+                "success": False,
+                "error": None,
+            }
+
+            if not self._checkout_branch(repo_path, branch):
+                branch_result["error"] = "Failed to checkout branch"
+                results["branches_failed"] += 1
+            elif not self._merge_main(repo_path):
+                branch_result["error"] = "Failed to merge origin/main"
+                results["branches_failed"] += 1
+            elif not self._push_branch(repo_path, branch):
+                branch_result["error"] = "Failed to push branch"
+                results["branches_failed"] += 1
+            else:
+                branch_result["success"] = True
+                results["branches_updated"] += 1
+
+            results["branch_results"].append(branch_result)
+
+        if results["branches_failed"] > 0:
+            results["success"] = False
+
+        self.logger.info(
+            f"UpdatePRBranchesWorker completed for {repo_path.name}. "
+            f"Updated: {results['branches_updated']}, Failed: {results['branches_failed']}"
+        )
+
+        return results
+
+    def _get_open_pr_branches(self, repo_dir: Path) -> List[str]:
+        """Get list of branches from open PRs in the repository."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "list", "--state=open", "--json=headRefName"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            if result.returncode != 0:
+                self.logger.error(f"Failed to list PRs in {repo_dir.name}: {result.stderr}")
+                return []
+
+            prs = json.loads(result.stdout)
+            return [pr["headRefName"] for pr in prs]
+
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"Timeout getting PRs from {repo_dir.name}")
+            return []
+        except Exception as e:
+            self.logger.error(f"Error getting PRs from {repo_dir.name}: {str(e)}")
+            return []
+
+    def _checkout_branch(self, repo_dir: Path, branch: str) -> bool:
+        """Checkout a specific branch in the repository."""
+        success = checkout_branch_resilient(repo_dir=repo_dir, branch=branch, fetch_first=True, timeout=60)
+
+        if success:
+            self.logger.info(f"Successfully checked out {branch} in {repo_dir.name}")
+        else:
+            self.logger.error(f"Failed to checkout {branch} in {repo_dir.name}")
+
+        return success
+
+    def _merge_main(self, repo_dir: Path) -> bool:
+        """Merge origin/main into the current branch."""
+        try:
+            self.logger.info(f"Merging origin/main into current branch in {repo_dir.name}")
+
+            fetch_result = subprocess.run(
+                ["git", "fetch", "origin", "main:main"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if fetch_result.returncode != 0:
+                self.logger.error(f"Failed to fetch main: {fetch_result.stderr}")
+                return False
+
+            merge_result = subprocess.run(
+                ["git", "merge", "origin/main", "--no-edit"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if merge_result.returncode != 0:
+                self.logger.warning(f"Merge had conflicts or failed: {merge_result.stderr}")
+                subprocess.run(
+                    ["git", "merge", "--abort"],
+                    cwd=repo_dir,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                return False
+
+            self.logger.info("Successfully merged origin/main into current branch")
+            return True
+
+        except subprocess.TimeoutExpired:
+            self.logger.error("Timeout merging main")
+            return False
+        except Exception as e:
+            self.logger.error(f"Error merging main: {str(e)}")
+            return False
+
+    def _push_branch(self, repo_dir: Path, branch: str) -> bool:
+        """Push the updated branch to remote."""
+        try:
+            self.logger.info(f"Pushing branch {branch} to remote")
+
+            result = subprocess.run(
+                ["git", "push", "origin", branch, "--force"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            if result.returncode != 0:
+                self.logger.error(f"Failed to push branch {branch}: {result.stderr}")
+                return False
+
+            self.logger.info(f"Successfully pushed branch {branch}")
+            return True
+
+        except subprocess.TimeoutExpired:
+            self.logger.error(f"Timeout pushing branch {branch}")
+            return False
+        except Exception as e:
+            self.logger.error(f"Error pushing branch {branch}: {str(e)}")
+            return False

--- a/tests/test_update_pr_branches_worker.py
+++ b/tests/test_update_pr_branches_worker.py
@@ -1,0 +1,231 @@
+"""Tests for UpdatePRBranchesWorker."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from auto_slopp.workers.update_pr_branches_worker import UpdatePRBranchesWorker
+
+
+class TestUpdatePRBranchesWorker:
+    """Test cases for UpdatePRBranchesWorker."""
+
+    @pytest.fixture
+    def temp_repo_dir(self):
+        """Create a temporary repository directory for testing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_dir = Path(temp_dir) / "test_repo"
+            repo_dir.mkdir()
+            os.chdir(repo_dir)
+            os.system("git init")
+            os.system("git config user.email 'test@example.com'")
+            os.system("git config user.name 'Test User'")
+            os.system("git checkout -b main")
+            os.system("echo 'test' > test.txt")
+            os.system("git add test.txt")
+            os.system("git commit -m 'Initial commit'")
+            yield repo_dir
+
+    @pytest.fixture
+    def temp_task_dir(self):
+        """Create a temporary task directory for testing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield Path(temp_dir) / "test_task"
+
+    def test_worker_initialization(self):
+        """Test worker initialization."""
+        worker = UpdatePRBranchesWorker()
+        assert worker is not None
+        assert worker.logger is not None
+
+    def test_run_with_nonexistent_repo(self, temp_task_dir):
+        """Test run with non-existent repository."""
+        worker = UpdatePRBranchesWorker()
+        result = worker.run(Path("/tmp/nonexistent"), temp_task_dir)
+
+        assert result["success"] is False
+        assert result["worker_name"] == "UpdatePRBranchesWorker"
+        assert "does not exist" in result["error"]
+
+    def test_get_open_pr_branches_empty(self, temp_repo_dir, temp_task_dir):
+        """Test getting open PR branches when none exist."""
+        worker = UpdatePRBranchesWorker()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(
+                stdout="[]",
+                stderr="",
+                returncode=0,
+            )
+
+            branches = worker._get_open_pr_branches(temp_repo_dir)
+            assert branches == []
+
+    def test_get_open_pr_branches_with_prs(self, temp_repo_dir):
+        """Test getting open PR branches when PRs exist."""
+        worker = UpdatePRBranchesWorker()
+
+        pr_data = [
+            {"headRefName": "feature-branch-1"},
+            {"headRefName": "feature-branch-2"},
+        ]
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(
+                stdout=json.dumps(pr_data),
+                stderr="",
+                returncode=0,
+            )
+
+            branches = worker._get_open_pr_branches(temp_repo_dir)
+            assert branches == ["feature-branch-1", "feature-branch-2"]
+
+    def test_get_open_pr_branches_error(self, temp_repo_dir):
+        """Test error handling when getting PR branches fails."""
+        worker = UpdatePRBranchesWorker()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(
+                stdout="",
+                stderr="Error getting PRs",
+                returncode=1,
+            )
+
+            branches = worker._get_open_pr_branches(temp_repo_dir)
+            assert branches == []
+
+    @patch("auto_slopp.workers.update_pr_branches_worker.checkout_branch_resilient")
+    def test_checkout_branch_success(self, mock_checkout, temp_repo_dir):
+        """Test successful branch checkout."""
+        worker = UpdatePRBranchesWorker()
+        mock_checkout.return_value = True
+
+        result = worker._checkout_branch(temp_repo_dir, "feature-branch")
+
+        assert result is True
+        mock_checkout.assert_called_once()
+
+    @patch("auto_slopp.workers.update_pr_branches_worker.checkout_branch_resilient")
+    def test_checkout_branch_failure(self, mock_checkout, temp_repo_dir):
+        """Test failed branch checkout."""
+        worker = UpdatePRBranchesWorker()
+        mock_checkout.return_value = False
+
+        result = worker._checkout_branch(temp_repo_dir, "feature-branch")
+
+        assert result is False
+
+    @patch("subprocess.run")
+    def test_merge_main_success(self, mock_run, temp_repo_dir):
+        """Test successful merge of origin/main."""
+        worker = UpdatePRBranchesWorker()
+
+        mock_run.return_value = Mock(
+            stdout="Merge completed",
+            stderr="",
+            returncode=0,
+        )
+
+        result = worker._merge_main(temp_repo_dir)
+
+        assert result is True
+        assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_merge_main_failure(self, mock_run, temp_repo_dir):
+        """Test failed merge of origin/main."""
+        worker = UpdatePRBranchesWorker()
+
+        mock_run.return_value = Mock(
+            stdout="",
+            stderr="Merge conflict",
+            returncode=1,
+        )
+
+        result = worker._merge_main(temp_repo_dir)
+
+        assert result is False
+        assert mock_run.call_count >= 1
+
+    @patch("subprocess.run")
+    def test_push_branch_success(self, mock_run, temp_repo_dir):
+        """Test successful push of branch."""
+        worker = UpdatePRBranchesWorker()
+
+        mock_run.return_value = Mock(
+            stdout="Pushed",
+            stderr="",
+            returncode=0,
+        )
+
+        result = worker._push_branch(temp_repo_dir, "feature-branch")
+
+        assert result is True
+
+    @patch("subprocess.run")
+    def test_push_branch_failure(self, mock_run, temp_repo_dir):
+        """Test failed push of branch."""
+        worker = UpdatePRBranchesWorker()
+
+        mock_run.return_value = Mock(
+            stdout="",
+            stderr="Push failed",
+            returncode=1,
+        )
+
+        result = worker._push_branch(temp_repo_dir, "feature-branch")
+
+        assert result is False
+
+    def test_result_structure(self, temp_repo_dir, temp_task_dir):
+        """Test that worker result has correct structure."""
+        worker = UpdatePRBranchesWorker()
+
+        with patch.object(worker, "_get_open_pr_branches", return_value=[]):
+            result = worker.run(temp_repo_dir, temp_task_dir)
+
+        assert "worker_name" in result
+        assert result["worker_name"] == "UpdatePRBranchesWorker"
+        assert "success" in result
+        assert "branches_updated" in result
+        assert "branches_failed" in result
+        assert "branch_results" in result
+        assert isinstance(result["branches_updated"], int)
+        assert isinstance(result["branches_failed"], int)
+        assert isinstance(result["branch_results"], list)
+
+    @patch("auto_slopp.workers.update_pr_branches_worker.checkout_branch_resilient")
+    @patch("subprocess.run")
+    def test_full_workflow(self, mock_run, mock_checkout, temp_repo_dir, temp_task_dir):
+        """Test full workflow of updating PR branches."""
+        worker = UpdatePRBranchesWorker()
+
+        mock_checkout.return_value = True
+
+        def run_side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("cmd", [])
+            if "gh" in cmd:
+                return Mock(
+                    stdout=json.dumps([{"headRefName": "feature-branch"}]),
+                    stderr="",
+                    returncode=0,
+                )
+            if "fetch" in cmd:
+                return Mock(stdout="", stderr="", returncode=0)
+            if "merge" in cmd:
+                return Mock(stdout="", stderr="", returncode=0)
+            if "push" in cmd:
+                return Mock(stdout="", stderr="", returncode=0)
+            return Mock(stdout="", stderr="", returncode=0)
+
+        mock_run.side_effect = run_side_effect
+
+        result = worker.run(temp_repo_dir, temp_task_dir)
+
+        assert result["success"] is True
+        assert result["branches_updated"] == 1
+        assert result["branches_failed"] == 0


### PR DESCRIPTION
## Summary
- Added new worker UpdatePRBranchesWorker that updates branches of open pull requests
- Worker checks out each open PR branch, merges origin/main into it, and pushes the result
- Reuses existing checkout_branch_resilient function from git_operations
- Added comprehensive tests for the new worker