### PR TITLE
Add GitHubIssueWorker to process issues as instructions

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -60,6 +60,130 @@ def _run_gh_command(
         raise GitHubOperationError(f"GitHub command timed out: {e}")
 
 
+def get_open_issues(repo_dir: Path) -> List[Dict[str, Any]]:
+    """Get list of open issues in the repository.
+
+    Args:
+        repo_dir: Path to the git repository
+
+    Returns:
+        List of dictionaries containing issue information (number, title, body, url).
+
+    Raises:
+        GitHubOperationError: If gh command fails
+    """
+    try:
+        result = _run_gh_command(
+            repo_dir,
+            "issue",
+            "list",
+            "--state=open",
+            "--json=number,title,body,url",
+            check=False,
+        )
+
+        if result.returncode != 0:
+            issue_error = result.stderr.strip() or result.stdout.strip()
+            logger.error(f"Failed to list issues in {repo_dir.name}: {issue_error}")
+            return []
+
+        issues = json.loads(result.stdout)
+        return issues
+
+    except GitHubOperationError as e:
+        logger.error(f"Error getting issues from {repo_dir.name}: {str(e)}")
+        return []
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse issue list JSON from {repo_dir.name}: {str(e)}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error getting issues from {repo_dir.name}: {str(e)}")
+        return []
+
+
+def close_issue(repo_dir: Path, issue_number: int) -> bool:
+    """Close an issue in the repository.
+
+    Args:
+        repo_dir: Path to the git repository
+        issue_number: Issue number to close
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    try:
+        result = _run_gh_command(
+            repo_dir,
+            "issue",
+            "close",
+            str(issue_number),
+            check=False,
+        )
+        return result.returncode == 0
+
+    except GitHubOperationError as e:
+        logger.error(f"Error closing issue #{issue_number} in {repo_dir.name}: {str(e)}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error closing issue #{issue_number} in {repo_dir.name}: {str(e)}")
+        return False
+
+
+def create_pull_request(
+    repo_dir: Path,
+    title: str,
+    body: str,
+    head: str,
+    base: str = "main",
+) -> Optional[Dict[str, Any]]:
+    """Create a pull request in the repository.
+
+    Args:
+        repo_dir: Path to the git repository
+        title: PR title
+        body: PR body
+        head: Branch name to merge from
+        base: Branch name to merge into (default: main)
+
+    Returns:
+        Dictionary containing PR info (url, number) or None if failed.
+    """
+    try:
+        result = _run_gh_command(
+            repo_dir,
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+            "--head",
+            head,
+            "--base",
+            base,
+            "--json=url,number",
+            check=False,
+        )
+
+        if result.returncode != 0:
+            pr_error = result.stderr.strip() or result.stdout.strip()
+            logger.error(f"Failed to create PR in {repo_dir.name}: {pr_error}")
+            return None
+
+        pr_data = json.loads(result.stdout)
+        return pr_data
+
+    except GitHubOperationError as e:
+        logger.error(f"Error creating PR in {repo_dir.name}: {str(e)}")
+        return None
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse PR creation JSON from {repo_dir.name}: {str(e)}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error creating PR in {repo_dir.name}: {str(e)}")
+        return None
+
+
 def get_open_pr_branches(repo_dir: Path) -> List[str]:
     """Get list of branches from open PRs in the repository.
 

--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -5,12 +5,14 @@ This package contains all worker implementations organized by functionality:
 """
 
 # Import all workers to make them available for discovery
+from auto_slopp.workers.github_issue_worker import GitHubIssueWorker
 from auto_slopp.workers.pr_worker import PRWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 from auto_slopp.workers.task_processor_worker import TaskProcessorWorker
 from auto_slopp.workers.update_pr_branches_worker import UpdatePRBranchesWorker
 
 __all__ = [
+    "GitHubIssueWorker",
     "PRWorker",
     "StaleBranchCleanupWorker",
     "TaskProcessorWorker",

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -1,0 +1,274 @@
+"""GitHub Issue Worker for processing open issues as instructions.
+
+This worker:
+1. Searches each repository for open issues on GitHub
+2. Uses issue title/body as instructions (similar to TaskProcessorWorker)
+3. Creates a new branch starting with ai/
+4. Executes instructions using OpenCode
+5. Creates a PR and closes the issue
+"""
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from auto_slopp.utils.git_operations import (
+    checkout_branch_resilient,
+    commit_and_push_changes,
+)
+from auto_slopp.utils.github_operations import (
+    close_issue,
+    create_pull_request,
+    get_open_issues,
+)
+from auto_slopp.utils.opencode import execute_openagent_with_instructions
+from auto_slopp.worker import Worker
+
+
+class GitHubIssueWorker(Worker):
+    """Worker for processing GitHub issues as instructions.
+
+    This worker searches each repository for open issues on GitHub,
+    uses the issue title and body as instructions for OpenCode,
+    creates a new branch, executes the instructions, and creates a PR.
+    """
+
+    def __init__(
+        self,
+        timeout: int = 7200,
+        agent_args: Optional[List[str]] = None,
+        dry_run: bool = False,
+    ):
+        """Initialize the GitHubIssueWorker.
+
+        Args:
+            timeout: Timeout for OpenCode execution in seconds
+            agent_args: Additional arguments to pass to OpenCode
+            dry_run: If True, skip actual OpenCode execution and git operations
+        """
+        self.timeout = timeout
+        self.agent_args = agent_args or []
+        self.dry_run = dry_run
+        self.logger = logging.getLogger("auto_slopp.workers.GitHubIssueWorker")
+
+    def run(self, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Execute the GitHub issue processing workflow for a single repository.
+
+        Args:
+            repo_path: Path to the repository directory
+            task_path: Path to the task directory (unused but kept for signature)
+
+        Returns:
+            Dictionary containing execution results and statistics
+        """
+        start_time = self._get_current_time()
+        self.logger.info(f"GitHubIssueWorker starting with repo_path: {repo_path}")
+
+        if not repo_path.exists():
+            return self._create_error_result(
+                start_time,
+                repo_path,
+                task_path,
+                f"Repository path does not exist: {repo_path}",
+            )
+
+        results = self._create_results_dict(start_time, repo_path, task_path)
+
+        issue_result = self._process_single_issue(repo_path)
+        results["issue_results"].append(issue_result)
+
+        if issue_result.get("no_issues", False):
+            pass  # No issues to process
+        elif issue_result["success"]:
+            results["issues_processed"] += 1
+            results["openagent_executions"] += issue_result.get("openagent_executions", 0)
+            results["prs_created"] += issue_result.get("prs_created", 0)
+            results["issues_closed"] += issue_result.get("issues_closed", 0)
+        else:
+            results["repositories_with_errors"] += 1
+            results["success"] = False
+
+        results["execution_time"] = self._get_elapsed_time(start_time)
+        self._log_completion_summary(results)
+
+        return results
+
+    def _create_results_dict(self, start_time: float, repo_path: Path, task_path: Path) -> Dict[str, Any]:
+        """Create the initial results dictionary."""
+        return {
+            "worker_name": "GitHubIssueWorker",
+            "execution_time": 0,
+            "timestamp": start_time,
+            "repo_path": str(repo_path),
+            "task_path": str(task_path),
+            "dry_run": self.dry_run,
+            "repositories_processed": 1,
+            "repositories_with_errors": 0,
+            "issues_processed": 0,
+            "openagent_executions": 0,
+            "prs_created": 0,
+            "issues_closed": 0,
+            "issue_results": [],
+            "success": True,
+        }
+
+    def _process_single_issue(self, repo_dir: Path) -> Dict[str, Any]:
+        """Process a single issue from the repository.
+
+        Args:
+            repo_dir: Path to the repository directory
+
+        Returns:
+            Processing result for this issue
+        """
+        self.logger.info(f"Processing GitHub issues for: {repo_dir.name}")
+
+        if not self.dry_run:
+            pull_success = checkout_branch_resilient(
+                repo_dir=repo_dir,
+                branch="main",
+                fetch_first=True,
+                timeout=60,
+            )
+            if not pull_success:
+                self.logger.warning(f"Failed to pull latest changes from {repo_dir.name}")
+
+        issues = get_open_issues(repo_dir)
+
+        if not issues:
+            self.logger.info(f"No open issues found in {repo_dir.name}")
+            return {
+                "repository": repo_dir.name,
+                "success": True,
+                "no_issues": True,
+            }
+
+        issue = issues[0]
+        issue_number = issue["number"]
+        issue_title = issue["title"]
+        issue_body = issue.get("body", "") or ""
+
+        self.logger.info(f"Processing issue #{issue_number}: {issue_title}")
+
+        result = {
+            "repository": repo_dir.name,
+            "issue_number": issue_number,
+            "issue_title": issue_title,
+            "success": False,
+            "openagent_executed": False,
+            "pr_created": False,
+            "issue_closed": False,
+            "error": None,
+        }
+
+        try:
+            instructions = self._build_instructions(issue_title, issue_body)
+            branch_name = f"ai/issue-{issue_number}-{issue_title[:30].replace(' ', '-').lower()}"
+
+            if self.dry_run:
+                self.logger.info(f"DRY RUN: Would create branch {branch_name} and execute instructions")
+                result["openagent_executed"] = True
+                result["success"] = True
+                return result
+
+            openagent_result = execute_openagent_with_instructions(
+                instructions, repo_dir, self.agent_args, self.timeout
+            )
+            result["openagent_executed"] = openagent_result["success"]
+
+            if not openagent_result["success"]:
+                result["error"] = f"OpenCode execution failed: {openagent_result.get('error', 'Unknown error')}"
+                return result
+
+            pr_body = f"Closes #{issue_number}\n\n{issue_body}"
+            pr_result = create_pull_request(
+                repo_dir,
+                title=issue_title,
+                body=pr_body,
+                head=branch_name,
+                base="main",
+            )
+
+            if pr_result:
+                result["pr_created"] = True
+                result["pr_url"] = pr_result.get("url", "")
+                self.logger.info(f"Created PR for issue #{issue_number}: {pr_result.get('url', 'N/A')}")
+            else:
+                result["error"] = "Failed to create pull request"
+                return result
+
+            close_success = close_issue(repo_dir, issue_number)
+            result["issue_closed"] = close_success
+
+            if not close_success:
+                self.logger.warning(f"Failed to close issue #{issue_number}")
+
+            result["success"] = True
+
+        except Exception as e:
+            self.logger.error(f"Error processing issue #{issue_number}: {str(e)}")
+            result["error"] = str(e)
+
+        return result
+
+    def _build_instructions(self, issue_title: str, issue_body: str) -> str:
+        """Build the instructions string from issue title and body.
+
+        Args:
+            issue_title: Issue title
+            issue_body: Issue body
+
+        Returns:
+            Complete instructions string
+        """
+        body_text = f"\n{issue_body}" if issue_body else ""
+        return (
+            f"Create a new branch that starts with ai/ from base origin/main and implement the following:\n"
+            f"Title: {issue_title}\n"
+            f"Description:{body_text}\n"
+            f"Keep your implementation simple. Only implement what is required. Check if there are components you can reuse. "
+            f"Ensure that 'make test' runs successful. Only push if ALL tests are successful. "
+            f"Check if you need to update the README.md. Push your changes and create a pull request on github."
+        )
+
+    def _create_error_result(
+        self, start_time: float, repo_path: Path, task_path: Path, error_msg: str
+    ) -> Dict[str, Any]:
+        """Create an error result dictionary."""
+        return {
+            "worker_name": "GitHubIssueWorker",
+            "execution_time": self._get_elapsed_time(start_time),
+            "timestamp": start_time,
+            "repo_path": str(repo_path),
+            "task_path": str(task_path),
+            "dry_run": self.dry_run,
+            "success": False,
+            "error": error_msg,
+            "repositories_processed": 0,
+            "repositories_with_errors": 1,
+            "issues_processed": 0,
+            "openagent_executions": 0,
+            "prs_created": 0,
+            "issues_closed": 0,
+            "issue_results": [],
+        }
+
+    def _get_current_time(self) -> float:
+        """Get current time as float for consistent timing."""
+        return time.time()
+
+    def _get_elapsed_time(self, start_time: float) -> float:
+        """Get elapsed time from start time."""
+        return time.time() - start_time
+
+    def _log_completion_summary(self, results: Dict[str, Any]) -> None:
+        """Log completion summary."""
+        self.logger.info(
+            f"GitHubIssueWorker completed. Processed: "
+            f"{results['issues_processed']}, "
+            f"OpenCode executions: {results['openagent_executions']}, "
+            f"PRs created: {results['prs_created']}, "
+            f"Issues closed: {results['issues_closed']}, "
+            f"Errors: {results['repositories_with_errors']}"
+        )

--- a/tests/test_github_issue_worker.py
+++ b/tests/test_github_issue_worker.py
@@ -1,0 +1,114 @@
+"""Tests for GitHubIssueWorker."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from auto_slopp.workers.github_issue_worker import GitHubIssueWorker
+
+
+class TestGitHubIssueWorker:
+    """Tests for GitHubIssueWorker."""
+
+    def test_initialization_success(self):
+        """Test successful worker initialization."""
+        worker = GitHubIssueWorker(
+            timeout=7200,
+            agent_args=["--verbose"],
+            dry_run=True,
+        )
+
+        assert worker.timeout == 7200
+        assert worker.agent_args == ["--verbose"]
+        assert worker.dry_run is True
+
+    def test_run_with_no_issues(self):
+        """Test run with no open issues."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+            task_path = Path(temp_dir) / "tasks"
+
+            with patch("auto_slopp.workers.github_issue_worker.get_open_issues") as mock_issues:
+                mock_issues.return_value = []
+
+                worker = GitHubIssueWorker(dry_run=True)
+                result = worker.run(repo_path, task_path)
+
+                assert result["success"] is True
+                assert result["repositories_processed"] == 1
+                assert result["repositories_with_errors"] == 0
+                assert result["issues_processed"] == 0
+
+    def test_run_with_issues_dry_run(self):
+        """Test run with open issues in dry run mode."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+            task_path = Path(temp_dir) / "tasks"
+
+            mock_issue = {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "This is a test issue",
+                "url": "https://github.com/test/repo/issues/1",
+            }
+
+            with patch("auto_slopp.workers.github_issue_worker.get_open_issues") as mock_issues:
+                mock_issues.return_value = [mock_issue]
+
+                worker = GitHubIssueWorker(dry_run=True)
+                result = worker.run(repo_path, task_path)
+
+                assert result["success"] is True
+                assert result["repositories_processed"] == 1
+                assert result["issues_processed"] == 1
+                assert result["issue_results"][0]["issue_number"] == 1
+                assert result["issue_results"][0]["issue_title"] == "Test Issue"
+
+    def test_run_with_nonexistent_repo(self):
+        """Test run with nonexistent repository path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "nonexistent_repo"
+            task_path = Path(temp_dir) / "tasks"
+
+            worker = GitHubIssueWorker(dry_run=True)
+            result = worker.run(repo_path, task_path)
+
+            assert result["success"] is False
+            assert "error" in result
+
+    def test_build_instructions(self):
+        """Test instruction building."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Fix bug", "This is a bug")
+        assert "Fix bug" in instructions
+        assert "This is a bug" in instructions
+        assert "ai/" in instructions
+
+    def test_build_instructions_empty_body(self):
+        """Test instruction building with empty body."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Test issue", "")
+        assert "Test issue" in instructions
+        assert "ai/" in instructions
+
+    def test_create_error_result(self):
+        """Test error result creation."""
+        worker = GitHubIssueWorker(dry_run=True)
+        start_time = 1000.0
+
+        result = worker._create_error_result(
+            start_time,
+            Path("/test/repo"),
+            Path("/test/tasks"),
+            "Test error",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "Test error"
+        assert result["worker_name"] == "GitHubIssueWorker"


### PR DESCRIPTION
## Summary
- Added new `GitHubIssueWorker` that searches each repository for open GitHub issues
- Uses issues as instructions similar to `TaskProcessorWorker`
- Creates a new branch starting with `ai/` for each issue
- Executes instructions using OpenCode
- Creates a PR and closes the issue when done
- Added helper functions to `github_operations.py`: `get_open_issues`, `close_issue`, `create_pull_request`
- Added tests for the new worker