### PR TITLE
Fix GitHubIssueWorker not closing issues with comment

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -129,6 +129,37 @@ def close_issue(repo_dir: Path, issue_number: int) -> bool:
         return False
 
 
+def comment_on_issue(repo_dir: Path, issue_number: int, comment: str) -> bool:
+    """Add a comment to an issue in the repository.
+
+    Args:
+        repo_dir: Path to the git repository
+        issue_number: Issue number to comment on
+        comment: Comment text to add
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    try:
+        result = _run_gh_command(
+            repo_dir,
+            "issue",
+            "comment",
+            str(issue_number),
+            "--body",
+            comment,
+            check=False,
+        )
+        return result.returncode == 0
+
+    except GitHubOperationError as e:
+        logger.error(f"Error commenting on issue #{issue_number} in {repo_dir.name}: {str(e)}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error commenting on issue #{issue_number} in {repo_dir.name}: {str(e)}")
+        return False
+
+
 def create_pull_request(
     repo_dir: Path,
     title: str,

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -19,6 +19,7 @@ from auto_slopp.utils.git_operations import (
 )
 from auto_slopp.utils.github_operations import (
     close_issue,
+    comment_on_issue,
     create_pull_request,
     get_open_issues,
 )
@@ -201,7 +202,14 @@ class GitHubIssueWorker(Worker):
             close_success = close_issue(repo_dir, issue_number)
             result["issue_closed"] = close_success
 
-            if not close_success:
+            if close_success:
+                pr_url = pr_result.get("url", "")
+                comment = f"Completed by PR: {pr_url}"
+                comment_success = comment_on_issue(repo_dir, issue_number, comment)
+                result["issue_commented"] = comment_success
+                if not comment_success:
+                    self.logger.warning(f"Failed to add comment to issue #{issue_number}")
+            else:
                 self.logger.warning(f"Failed to close issue #{issue_number}")
 
             result["success"] = True


### PR DESCRIPTION
## Summary

- Added `comment_on_issue` function in `github_operations.py` to add comments to GitHub issues
- Updated `GitHubIssueWorker` to add a comment linking to the PR after closing the issue

The worker now:
1. Creates a PR for the issue
2. Closes the issue
3. Adds a comment to the closed issue with the PR URL (e.g., "Completed by PR: https://github.com/...")