### PR TITLE
Rename opencode to cli_executor and add configurable CLI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ A Python-based automation framework for task execution with pluggable worker sys
 
 It is recommended to set the coding machine to allow everything it requires for its job. It is **not** recommended to let it ask for permission as this will break the flow of the auto slopper.
 
-### opencode.json Example
+### CLI Configuration
 
-Auto-slopp works well with [opencode.ai](https://opencode.ai). Here is an example configuration:
+Auto-slopp supports configurable CLI tools for automation. By default, it uses [opencode.ai](https://opencode.ai), but you can configure it to use other CLI tools like Claude Code.
+
+#### opencode.json Example (for opencode.ai)
 
 ```json
 {
@@ -30,6 +32,23 @@ Auto-slopp works well with [opencode.ai](https://opencode.ai). Here is an exampl
 }
 ```
 
+#### Environment Variables for CLI Configuration
+
+You can customize the CLI command and arguments via environment variables:
+
+```bash
+# CLI command to use (default: opencode)
+AUTO_SLOPP_CLI_COMMAND=opencode
+
+# Arguments to pass to the CLI command (default: ["--agent", "openagent", "--model", "opencode/glm-5-free", "run"])
+# For opencode.ai:
+AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
+
+# For Claude Code, you might use:
+# AUTO_SLOPP_CLI_COMMAND=claude
+# AUTO_SLOPP_CLI_ARGS='[]'
+```
+
 ## Recommended Addons
 
 ### OpenAgentsControl
@@ -37,7 +56,7 @@ Auto-slopp works well with [opencode.ai](https://opencode.ai). Here is an exampl
 [**OpenAgentsControl**](https://github.com/darrenhinde/OpenAgentsControl) is a recommended addon when using opencode. It is **required for the default settings** to work properly.
 
 - **Repository**: https://github.com/darrenhinde/OpenAgentsControl
-- **Required**: Yes (for default settings)
+- **Required**: Yes (for default settings with opencode)
 - **Recommended**: Yes (when using opencode)
 
 ## Installation
@@ -184,6 +203,10 @@ Create a `.env` file in the project root:
 AUTO_SLOPP_BASE_REPO_PATH=/path/to/your/repo
 AUTO_SLOPP_BASE_TASK_PATH=/path/to/your/tasks
 AUTO_SLOPP_DEBUG=false
+
+# CLI configuration (optional - defaults to opencode)
+AUTO_SLOPP_CLI_COMMAND=opencode
+AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
 
 # Telegram logging (optional)
 AUTO_SLOPP_TELEGRAM_ENABLED=true
@@ -355,6 +378,10 @@ class Settings(BaseSettings):
     executor_sleep_interval: float = Field(default=1.0)
     debug: bool = Field(default=False)
 
+    # CLI Configuration
+    cli_command: str = Field(default="opencode", description="CLI command to execute")
+    cli_args: list = Field(default=["--agent", "openagent", "--model", "opencode/glm-5-free", "run"])
+
     # Telegram integration
     telegram_enabled: bool = Field(default=False)
     telegram_bot_token: Optional[str] = Field(default=None)
@@ -445,6 +472,10 @@ export AUTO_SLOPP_DEBUG=false
 export AUTO_SLOPP_TELEGRAM_ENABLED=true
 export AUTO_SLOPP_TELEGRAM_BOT_TOKEN=prod_bot_token
 export AUTO_SLOPP_TELEGRAM_CHAT_ID=prod_chat_id
+
+# CLI configuration (optional)
+export AUTO_SLOPP_CLI_COMMAND=opencode
+export AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
 ```
 
 ### .env File
@@ -456,6 +487,10 @@ AUTO_SLOPP_BASE_TASK_PATH=/home/user/tasks
 AUTO_SLOPP_WORKER_SEARCH_PATH=/home/user/custom-workers
 AUTO_SLOPP_EXECUTOR_SLEEP_INTERVAL=2.0
 AUTO_SLOPP_DEBUG=false
+
+# CLI configuration (optional - defaults to opencode)
+AUTO_SLOPP_CLI_COMMAND=opencode
+AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
 
 # Telegram settings
 AUTO_SLOPP_TELEGRAM_ENABLED=true

--- a/src/auto_slopp/utils/cli_executor.py
+++ b/src/auto_slopp/utils/cli_executor.py
@@ -1,7 +1,7 @@
-"""OpenCode execution utilities for auto-slopp workers.
+"""CLI executor utilities for auto-slopp workers.
 
-This module provides a centralized utility for executing OpenCode commands
-with consistent error handling, logging, and result formatting.
+This module provides a centralized utility for executing configured CLI commands
+(e.g., opencode, claude code) with consistent error handling, logging, and result formatting.
 """
 
 import logging
@@ -11,26 +11,28 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from settings.main import settings
+
 logger = logging.getLogger(__name__)
 
 
-def run_opencode(
+def run_cli_executor(
     additional_instructions: Optional[str] = None,
     working_directory: Optional[Path] = None,
     timeout: int = 7200,
     agent_args: Optional[List[str]] = None,
     capture_output: bool = True,
 ) -> Dict[str, Any]:
-    """Execute OpenCode with the specified parameters.
+    """Execute the configured CLI command with the specified parameters.
 
-    This centralized utility handles OpenCode execution with consistent
+    This centralized utility handles CLI execution with consistent
     error handling, logging, and result formatting across all workers.
 
     Args:
-        additional_instructions: Additional instructions to pass to OpenCode
-        working_directory: Directory where OpenCode should be executed
+        additional_instructions: Additional instructions to pass to the CLI
+        working_directory: Directory where the CLI should be executed
         timeout: Command execution timeout in seconds (default: 7200)
-        agent_args: Additional arguments to pass to OpenCode
+        agent_args: Additional arguments to pass to the CLI
         capture_output: Whether to capture stdout/stderr (default: True)
 
     Returns:
@@ -51,7 +53,7 @@ def run_opencode(
     Examples:
         Basic usage:
         ```python
-        result = run_opencode(
+        result = run_cli_executor(
             additional_instructions="Fix the failing tests",
             working_directory=Path("/path/to/repo"),
             timeout=1800
@@ -60,7 +62,7 @@ def run_opencode(
 
         With custom agent arguments:
         ```python
-        result = run_opencode(
+        result = run_cli_executor(
             additional_instructions="Implement new feature",
             working_directory=Path("/path/to/repo"),
             agent_args=["--verbose", "--debug"],
@@ -70,7 +72,7 @@ def run_opencode(
 
         Without output capture (for interactive commands):
         ```python
-        result = run_opencode(
+        result = run_cli_executor(
             additional_instructions="Run interactive setup",
             working_directory=Path("/path/to/repo"),
             capture_output=False
@@ -79,26 +81,25 @@ def run_opencode(
     """
     start_time = time.time()
 
-    # Set default values
     agent_args = agent_args or []
     working_dir = working_directory or Path.cwd()
 
+    cli_command = settings.cli_command
+    cli_base_args = settings.cli_args
+
     logger.info(
-        f"Executing OpenCode with instructions: {additional_instructions if additional_instructions else 'None'}..."
+        f"Executing {cli_command} with instructions: {additional_instructions if additional_instructions else 'None'}..."
     )
     logger.info(f"Working directory: {working_dir}")
     logger.info(f"Timeout: {timeout}s")
     logger.info(f"Agent args: {agent_args}")
 
-    # Build the OpenCode command
-    cmd = ["opencode", "--agent", "openagent", "--model", "opencode/glm-5-free", "run"] + agent_args
+    cmd = [cli_command] + cli_base_args + agent_args
 
-    # Add additional instructions as the last argument if provided
     if additional_instructions:
         cmd.append(additional_instructions)
 
     try:
-        # Execute the command
         result = subprocess.run(
             cmd,
             cwd=working_dir,
@@ -110,7 +111,6 @@ def run_opencode(
         execution_time = time.time() - start_time
         success = result.returncode == 0
 
-        # Prepare the standardized result
         execution_result = {
             "success": success,
             "execution_time": execution_time,
@@ -121,7 +121,6 @@ def run_opencode(
             "timeout": False,
         }
 
-        # Add output if captured
         if capture_output:
             execution_result.update(
                 {
@@ -133,9 +132,9 @@ def run_opencode(
             )
 
         if success:
-            logger.info(f"OpenCode completed successfully in {execution_time:.2f}s")
+            logger.info(f"{cli_command} completed successfully in {execution_time:.2f}s")
         else:
-            logger.error(f"OpenCode failed with return code {result.returncode} in {execution_time:.2f}s")
+            logger.error(f"{cli_command} failed with return code {result.returncode} in {execution_time:.2f}s")
             if capture_output and result.stderr:
                 logger.error(f"stderr: {result.stderr}")
 
@@ -143,7 +142,7 @@ def run_opencode(
 
     except subprocess.TimeoutExpired:
         execution_time = time.time() - start_time
-        error_msg = f"OpenCode timed out after {timeout} seconds"
+        error_msg = f"{cli_command} timed out after {timeout} seconds"
         logger.error(error_msg)
 
         return {
@@ -158,26 +157,87 @@ def run_opencode(
         }
 
 
+def execute_with_instructions(
+    instructions: str,
+    work_dir: Path,
+    agent_args: Optional[List[str]] = None,
+    timeout: int = 7200,
+) -> Dict[str, Any]:
+    """Execute CLI with specific instructions.
+
+    Args:
+        instructions: The instructions to pass to the CLI
+        work_dir: Working directory for command execution
+        agent_args: Additional arguments to pass to the CLI
+        timeout: Command execution timeout in seconds
+
+    Returns:
+        Dictionary containing execution results.
+    """
+    return run_cli_executor(
+        additional_instructions=instructions,
+        working_directory=work_dir,
+        agent_args=agent_args,
+        timeout=timeout,
+    )
+
+
+def run_opencode(
+    additional_instructions: Optional[str] = None,
+    working_directory: Optional[Path] = None,
+    timeout: int = 7200,
+    agent_args: Optional[List[str]] = None,
+    capture_output: bool = True,
+) -> Dict[str, Any]:
+    """Backward-compatible wrapper for run_cli_executor.
+
+    This function is deprecated and will be removed in a future version.
+    Use run_cli_executor instead.
+
+    Args:
+        additional_instructions: Additional instructions to pass to the CLI
+        working_directory: Directory where the CLI should be executed
+        timeout: Command execution timeout in seconds (default: 7200)
+        agent_args: Additional arguments to pass to the CLI
+        capture_output: Whether to capture stdout/stderr (default: True)
+
+    Returns:
+        Dictionary containing execution results.
+    """
+    logger.warning("run_opencode is deprecated, use run_cli_executor instead")
+    return run_cli_executor(
+        additional_instructions=additional_instructions,
+        working_directory=working_directory,
+        timeout=timeout,
+        agent_args=agent_args,
+        capture_output=capture_output,
+    )
+
+
 def execute_openagent_with_instructions(
     instructions: str,
     work_dir: Path,
     agent_args: Optional[List[str]] = None,
     timeout: int = 7200,
 ) -> Dict[str, Any]:
-    """Execute OpenAgent with specific instructions.
+    """Backward-compatible wrapper for execute_with_instructions.
+
+    This function is deprecated and will be removed in a future version.
+    Use execute_with_instructions instead.
 
     Args:
-        instructions: The instructions to pass to OpenAgent
+        instructions: The instructions to pass to the CLI
         work_dir: Working directory for command execution
-        agent_args: Additional arguments to pass to OpenAgent
+        agent_args: Additional arguments to pass to the CLI
         timeout: Command execution timeout in seconds
 
     Returns:
         Dictionary containing execution results.
     """
-    return run_opencode(
-        additional_instructions=instructions,
-        working_directory=work_dir,
+    logger.warning("execute_openagent_with_instructions is deprecated, use execute_with_instructions instead")
+    return execute_with_instructions(
+        instructions=instructions,
+        work_dir=work_dir,
         agent_args=agent_args,
         timeout=timeout,
     )

--- a/src/auto_slopp/utils/git_operations.py
+++ b/src/auto_slopp/utils/git_operations.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from auto_slopp.utils.opencode import run_opencode
+from auto_slopp.utils.cli_executor import run_cli_executor
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ def _handle_git_operation_failure(
     )
 
     try:
-        result = run_opencode(
+        result = run_cli_executor(
             additional_instructions=instructions,
             working_directory=repo_dir,
             timeout=timeout,

--- a/src/auto_slopp/utils/task_processing.py
+++ b/src/auto_slopp/utils/task_processing.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from auto_slopp.utils.cli_executor import execute_with_instructions, run_cli_executor
 from auto_slopp.utils.file_operations import (
     find_text_files,
     read_file_content,
@@ -15,7 +16,6 @@ from auto_slopp.utils.file_operations import (
 )
 from auto_slopp.utils.git_operations import commit_and_push_changes, get_current_branch
 from auto_slopp.utils.github_operations import create_pull_request
-from auto_slopp.utils.opencode import execute_openagent_with_instructions, run_opencode
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def process_text_file(
         instructions = f"Create a new branch that starts with ai/ from base origin/main and implement the following:\n{instructions}\nKeep your implementation simple. Only implement what is required. Check if there are components you can reuse. Ensure that 'make test' runs successful. Only push if ALL tests are successful. Check if you need to update the README.md. Push your changes and create a pull request on github."
         # Execute OpenAgent with the instructions
         if not dry_run:
-            openagent_result = execute_openagent_with_instructions(instructions, repo_dir, agent_args, timeout)
+            openagent_result = execute_with_instructions(instructions, repo_dir, agent_args, timeout)
             result["openagent_executed"] = openagent_result["success"]
 
             if not openagent_result["success"]:
@@ -112,7 +112,7 @@ def process_text_file(
             current_branch = get_current_branch(repo_dir)
             logger.info(f"Current branch after OpenCode execution: {current_branch}")
 
-            push_branch_result = run_opencode(
+            push_branch_result = run_cli_executor(
                 additional_instructions=f"git push -u origin {current_branch}",
                 working_directory=repo_dir,
                 timeout=60,
@@ -252,7 +252,7 @@ def process_repository(
 
         # Push the changes to remote
         if not dry_run and result["success"]:
-            push_result = run_opencode(
+            push_result = run_cli_executor(
                 additional_instructions="git push origin main",
                 working_directory=repo_dir,
                 timeout=60,

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from auto_slopp.utils.cli_executor import execute_with_instructions
 from auto_slopp.utils.git_operations import (
     checkout_branch_resilient,
     commit_and_push_changes,
@@ -24,7 +25,6 @@ from auto_slopp.utils.github_operations import (
     get_issue_comments,
     get_open_issues,
 )
-from auto_slopp.utils.opencode import execute_openagent_with_instructions
 from auto_slopp.worker import Worker
 
 
@@ -177,9 +177,7 @@ class GitHubIssueWorker(Worker):
                 result["success"] = True
                 return result
 
-            openagent_result = execute_openagent_with_instructions(
-                instructions, repo_dir, self.agent_args, self.timeout
-            )
+            openagent_result = execute_with_instructions(instructions, repo_dir, self.agent_args, self.timeout)
             result["openagent_executed"] = openagent_result["success"]
 
             if not openagent_result["success"]:

--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -9,13 +9,13 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List
 
+from auto_slopp.utils.cli_executor import run_cli_executor
 from auto_slopp.utils.git_operations import (
     checkout_branch_resilient,
     merge_main_into_branch,
     push_branch,
 )
 from auto_slopp.utils.github_operations import get_open_pr_branches
-from auto_slopp.utils.opencode import run_opencode
 from auto_slopp.utils.repository_utils import discover_repositories, validate_repository
 from auto_slopp.worker import Worker
 
@@ -300,7 +300,7 @@ class PRWorker(Worker):
         """
         additional_instructions = "'make test' is failing fix it and push the changes"
 
-        result = run_opencode(
+        result = run_cli_executor(
             additional_instructions=additional_instructions,
             working_directory=repo_dir,
             timeout=self.timeout,

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -93,6 +93,16 @@ class Settings(BaseSettings):
         default=False, description="Disable notification sound for Telegram messages"
     )
 
+    cli_command: str = Field(
+        default="opencode",
+        description="CLI command to execute for automation tasks (e.g., opencode, claude)",
+    )
+
+    cli_args: list = Field(
+        default=["--agent", "openagent", "--model", "opencode/glm-5-free", "run"],
+        description="Arguments to pass to the CLI command",
+    )
+
     model_config = {
         "env_prefix": "AUTO_SLOPP_",
         "env_file": ".env",

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -58,14 +58,17 @@ class TestCheckoutBranchResilient:
         assert mock_subprocess_run.call_count == 6
 
     @patch("auto_slopp.utils.git_operations.subprocess.run")
-    @patch("auto_slopp.utils.git_operations.run_opencode")
-    def test_checkout_failure_after_reset(self, mock_run_opencode, mock_subprocess_run):
+    @patch("auto_slopp.utils.git_operations.run_cli_executor")
+    def test_checkout_failure_after_reset(self, mock_run_cli_executor, mock_subprocess_run):
         """Test checkout failure even after reset."""
         repo_dir = Path("/tmp/test_repo")
         branch = "feature/test"
 
-        # Mock run_opencode to avoid actual execution
-        mock_run_opencode.return_value = {"success": False, "error": "OpenCode failed"}
+        # Mock run_cli_executor to avoid actual execution
+        mock_run_cli_executor.return_value = {
+            "success": False,
+            "error": "CLI executor failed",
+        }
 
         # Mock git commands: both checkout attempts fail
         mock_subprocess_run.side_effect = [
@@ -82,14 +85,17 @@ class TestCheckoutBranchResilient:
         assert mock_subprocess_run.call_count == 5
 
     @patch("auto_slopp.utils.git_operations.subprocess.run")
-    @patch("auto_slopp.utils.git_operations.run_opencode")
-    def test_checkout_reset_failure(self, mock_run_opencode, mock_subprocess_run):
+    @patch("auto_slopp.utils.git_operations.run_cli_executor")
+    def test_checkout_reset_failure(self, mock_run_cli_executor, mock_subprocess_run):
         """Test checkout failure when reset itself fails."""
         repo_dir = Path("/tmp/test_repo")
         branch = "feature/test"
 
-        # Mock run_opencode to avoid actual execution
-        mock_run_opencode.return_value = {"success": False, "error": "OpenCode failed"}
+        # Mock run_cli_executor to avoid actual execution
+        mock_run_cli_executor.return_value = {
+            "success": False,
+            "error": "CLI executor failed",
+        }
 
         # Mock git commands: checkout fails, reset also fails
         mock_subprocess_run.side_effect = [


### PR DESCRIPTION
## Summary
- Renamed `opencode.py` to `cli_executor.py` with generic naming to support multiple CLI tools
- Added CLI configuration settings (`cli_command`, `cli_args`) to the Settings class
- Updated all imports from `opencode` to `cli_executor`
- Added backward-compatible wrapper functions with deprecation warnings for existing code
- Updated tests to use new module name
- Updated README.md with CLI configuration documentation

## Configuration
Users can now configure the CLI command and arguments via environment variables:
- `AUTO_SLOPP_CLI_COMMAND`: CLI command to use (default: `opencode`)
- `AUTO_SLOPP_CLI_ARGS`: Arguments to pass to the CLI command (default: `["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]`)

This allows users to use alternative CLI tools like Claude Code by setting:
```bash
AUTO_SLOPP_CLI_COMMAND=claude
AUTO_SLOPP_CLI_ARGS='[]'
```

Closes #145