### PR TITLE
Renovate issue should be ignored

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -78,7 +78,7 @@ def get_open_issues(repo_dir: Path) -> List[Dict[str, Any]]:
             "issue",
             "list",
             "--state=open",
-            "--json=number,title,body,url",
+            "--json=number,title,body,url,author,labels",
             check=False,
         )
 

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -95,6 +95,8 @@ class GitHubIssueWorker(Worker):
             self._log_completion_summary(results)
             return results
 
+        issues = self._filter_renovate_issues(issues)
+
         for issue in issues:
             issue_result = self._process_single_issue(repo_path, issue)
             results["issue_results"].append(issue_result)
@@ -152,6 +154,44 @@ class GitHubIssueWorker(Worker):
                 self.logger.warning(f"Failed to pull latest changes from {repo_dir.name}")
                 return False
         return True
+
+    def _is_renovate_issue(self, issue: Dict[str, Any]) -> bool:
+        """Check if an issue is created by Renovate.
+
+        Args:
+            issue: The issue dictionary from GitHub API
+
+        Returns:
+            True if the issue is from Renovate, False otherwise
+        """
+        author = issue.get("author", {})
+        author_login = author.get("login", "") if author else ""
+        if author_login in ("renovate[bot]", "renovate"):
+            return True
+
+        labels = issue.get("labels", [])
+        label_names = [label.get("name", "") for label in labels]
+        if "renovate" in label_names:
+            return True
+
+        return False
+
+    def _filter_renovate_issues(self, issues: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Filter out issues created by Renovate.
+
+        Args:
+            issues: List of issue dictionaries
+
+        Returns:
+            List of issues with renovate issues removed
+        """
+        filtered = []
+        for issue in issues:
+            if self._is_renovate_issue(issue):
+                self.logger.info(f"Skipping renovate issue #{issue.get('number')}: {issue.get('title')}")
+            else:
+                filtered.append(issue)
+        return filtered
 
     def _process_single_issue(self, repo_dir: Path, issue: Dict[str, Any]) -> Dict[str, Any]:
         """Process a single issue from the repository.

--- a/tests/test_github_issue_worker.py
+++ b/tests/test_github_issue_worker.py
@@ -164,3 +164,124 @@ class TestGitHubIssueWorker:
                 mock_close.assert_called_once()
                 mock_comment.assert_called_once()
                 mock_delete.assert_called_once()
+
+    def test_is_renovate_issue_by_author_renovate_bot(self):
+        """Test detection of renovate issues by author renovate[bot]."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        issue = {
+            "number": 1,
+            "title": "Update dependencies",
+            "body": "Update dependencies",
+            "url": "https://github.com/test/repo/issues/1",
+            "author": {"login": "renovate[bot]"},
+        }
+
+        assert worker._is_renovate_issue(issue) is True
+
+    def test_is_renovate_issue_by_author_renovate(self):
+        """Test detection of renovate issues by author renovate."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        issue = {
+            "number": 1,
+            "title": "Update dependencies",
+            "body": "Update dependencies",
+            "url": "https://github.com/test/repo/issues/1",
+            "author": {"login": "renovate"},
+        }
+
+        assert worker._is_renovate_issue(issue) is True
+
+    def test_is_renovate_issue_by_label(self):
+        """Test detection of renovate issues by renovate label."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        issue = {
+            "number": 1,
+            "title": "Update dependencies",
+            "body": "Update dependencies",
+            "url": "https://github.com/test/repo/issues/1",
+            "labels": [{"name": "renovate"}],
+        }
+
+        assert worker._is_renovate_issue(issue) is True
+
+    def test_is_renovate_issue_false(self):
+        """Test that regular issues are not detected as renovate."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        issue = {
+            "number": 1,
+            "title": "Fix bug",
+            "body": "Fix a bug",
+            "url": "https://github.com/test/repo/issues/1",
+            "author": {"login": "developer"},
+            "labels": [{"name": "bug"}],
+        }
+
+        assert worker._is_renovate_issue(issue) is False
+
+    def test_filter_renovate_issues(self):
+        """Test filtering out renovate issues from list."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        issues = [
+            {
+                "number": 1,
+                "title": "Regular Issue",
+                "body": "A regular issue",
+                "author": {"login": "developer"},
+            },
+            {
+                "number": 2,
+                "title": "Renovate Issue",
+                "body": "Update dependencies",
+                "author": {"login": "renovate[bot]"},
+            },
+            {
+                "number": 3,
+                "title": "Another Regular Issue",
+                "body": "Another regular issue",
+                "author": {"login": "developer"},
+            },
+        ]
+
+        filtered = worker._filter_renovate_issues(issues)
+
+        assert len(filtered) == 2
+        assert filtered[0]["number"] == 1
+        assert filtered[1]["number"] == 3
+
+    def test_run_skips_renovate_issues(self):
+        """Test that worker skips renovate issues."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            issues = [
+                {
+                    "number": 1,
+                    "title": "Regular Issue",
+                    "body": "A regular issue",
+                    "url": "https://github.com/test/repo/issues/1",
+                    "author": {"login": "developer"},
+                },
+                {
+                    "number": 2,
+                    "title": "Renovate Issue",
+                    "body": "Update dependencies",
+                    "url": "https://github.com/test/repo/issues/2",
+                    "author": {"login": "renovate[bot]"},
+                },
+            ]
+
+            with patch("auto_slopp.workers.github_issue_worker.get_open_issues") as mock_issues:
+                mock_issues.return_value = issues
+
+                worker = GitHubIssueWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is True
+                assert result["issues_processed"] == 1
+                assert result["issue_results"][0]["issue_number"] == 1


### PR DESCRIPTION
Closes #185

Ensure that the issue that is created by renoveate for keeping track of dependencies is ingored by the githubissueworker