### PR TITLE
Default timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ AUTO_SLOPP_DEBUG=false
 # Available values: opencode, codex
 AUTO_SLOPP_SLOPMACHINE=codex
 
+# Timeout for slopmachine execution in seconds (default: 14400, 4 hours)
+# Controls how long the CLI tool is allowed to run before timing out
+AUTO_SLOPP_SLOP_TIMEOUT=14400
+
 # Optional CLI overrides (leave commented out to use slopmachine preset defaults)
 # AUTO_SLOPP_CLI_COMMAND=opencode
 # AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "run"]'

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ AUTO_SLOPP_CLI_COMMAND=opencode
 # For opencode.ai:
 AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "run"]'
 
+# Timeout for slopmachine execution in seconds (default: 14400, 4 hours)
+AUTO_SLOPP_SLOP_TIMEOUT=14400
+
 # For codex preset:
 # AUTO_SLOPP_SLOPMACHINE=codex
 # AUTO_SLOPP_CLI_COMMAND=codex
@@ -204,6 +207,9 @@ AUTO_SLOPP_WORKERS_DISABLED='[]'
 AUTO_SLOPP_SLOPMACHINE=opencode
 AUTO_SLOPP_CLI_COMMAND=opencode
 AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "run"]'
+
+# Timeout for slopmachine execution in seconds (default: 14400, 4 hours)
+AUTO_SLOPP_SLOP_TIMEOUT=14400
 
 # Telegram logging (optional)
 AUTO_SLOPP_TELEGRAM_ENABLED=true
@@ -386,6 +392,7 @@ class Settings(BaseSettings):
     slopmachine: Literal["opencode", "codex", "claude"] = Field(default="opencode")
     cli_command: str = Field(default="opencode", description="CLI command to execute")
     cli_args: list = Field(default=["--agent", "openagent", "run"])
+    slop_timeout: int = Field(default=14400, description="Timeout for slopmachine execution in seconds")
 
     # Telegram integration
     telegram_enabled: bool = Field(default=False)
@@ -496,6 +503,9 @@ export AUTO_SLOPP_TELEGRAM_CHAT_ID=prod_chat_id
 # CLI configuration (optional)
 export AUTO_SLOPP_CLI_COMMAND=opencode
 export AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
+
+# Timeout for slopmachine execution in seconds (default: 14400, 4 hours)
+export AUTO_SLOPP_SLOP_TIMEOUT=14400
 ```
 
 ### .env File
@@ -511,6 +521,9 @@ AUTO_SLOPP_DEBUG=false
 # CLI configuration (optional - defaults to opencode)
 AUTO_SLOPP_CLI_COMMAND=opencode
 AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "--model", "opencode/glm-5-free", "run"]'
+
+# Timeout for slopmachine execution in seconds (default: 14400, 4 hours)
+AUTO_SLOPP_SLOP_TIMEOUT=14400
 
 # Telegram settings
 AUTO_SLOPP_TELEGRAM_ENABLED=true

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -44,18 +44,18 @@ class GitHubIssueWorker(Worker):
 
     def __init__(
         self,
-        timeout: int = 7200,
+        timeout: int | None = None,
         agent_args: Optional[List[str]] = None,
         dry_run: bool = False,
     ):
         """Initialize the GitHubIssueWorker.
 
         Args:
-            timeout: Timeout for CLI execution in seconds
+            timeout: Timeout for CLI execution in seconds (default: from settings.slop_timeout)
             agent_args: Additional arguments to pass to the CLI tool
             dry_run: If True, skip actual CLI execution and git operations
         """
-        self.timeout = timeout
+        self.timeout = timeout if timeout is not None else settings.slop_timeout
         self.agent_args = agent_args or []
         self.dry_run = dry_run
         self.logger = logging.getLogger("auto_slopp.workers.GitHubIssueWorker")

--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -24,13 +24,13 @@ from settings.main import settings
 class PRWorker(Worker):
     """Worker for testing open PR branches and fixing failures with the configured CLI tool."""
 
-    def __init__(self, timeout: int = 600):
+    def __init__(self, timeout: int | None = None):
         """Initialize PRWorker.
 
         Args:
-            timeout: Timeout for test execution and OpenAgent fixes in seconds
+            timeout: Timeout for test execution and OpenAgent fixes in seconds (default: from settings.slop_timeout)
         """
-        self.timeout = timeout
+        self.timeout = timeout if timeout is not None else settings.slop_timeout
         self.logger = logging.getLogger("auto_slopp.workers.PRWorker")
 
     def run(self, repo_path: Path) -> Dict[str, Any]:

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -17,7 +17,13 @@ DEFAULT_WORKERS = [
 SLOPMACHINE_PRESETS = {
     "opencode": {
         "cli_command": "opencode",
-        "cli_args": ["--agent", "openagent", "--model", "zai-coding-plan/glm-4.7", "run"],
+        "cli_args": [
+            "--agent",
+            "openagent",
+            "--model",
+            "zai-coding-plan/glm-4.7",
+            "run",
+        ],
     },
     "codex": {
         "cli_command": "codex",
@@ -60,7 +66,8 @@ class Settings(BaseSettings):
         return v
 
     executor_sleep_interval: float = Field(
-        default=60.0, description="Sleep interval between executor iterations in seconds"
+        default=60.0,
+        description="Sleep interval between executor iterations in seconds",
     )
 
     debug: bool = Field(default=False, description="Enable debug mode with verbose logging")
@@ -104,6 +111,11 @@ class Settings(BaseSettings):
     cli_args: list = Field(
         default=["--agent", "openagent", "run"],
         description="Arguments to pass to the CLI command",
+    )
+
+    slop_timeout: int = Field(
+        default=14400,
+        description="Timeout for slopmachine execution in seconds (default: 4 hours)",
     )
 
     slopmachine: Literal["opencode", "codex", "claude"] = Field(


### PR DESCRIPTION
Closes #191

Set the default timeout for the slop machine to 4 hours.
Also make it adjustable via the settings