### PR TITLE
GitHub issueworker creates invalid Branch names

### DIFF
--- a/src/auto_slopp/utils/git_operations.py
+++ b/src/auto_slopp/utils/git_operations.py
@@ -6,6 +6,7 @@ used across different workers.
 
 import logging
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +16,28 @@ from auto_slopp.utils.cli_executor import run_cli_executor
 from settings.main import settings
 
 logger = logging.getLogger(__name__)
+
+
+def sanitize_branch_name(name: str, max_length: int = 50) -> str:
+    """Sanitize a string to be used as a valid git branch name.
+
+    Args:
+        name: The string to sanitize
+        max_length: Maximum length of the resulting branch name (default: 50)
+
+    Returns:
+        A sanitized branch name with only valid characters
+    """
+    name = name.strip()
+    name = name[:max_length]
+
+    name = re.sub(r"[^\w-]", "-", name)
+
+    name = re.sub(r"-+", "-", name)
+
+    name = name.strip("-")
+
+    return name or "branch"
 
 
 class GitOperationError(Exception):
@@ -747,46 +770,3 @@ def commit_all_changes(repo_dir: Path, commit_message: str) -> Tuple[bool, str]:
     except GitOperationError as e:
         error_msg = str(e)
         return False, f"Commit failed: {error_msg}"
-
-
-def pull_from_remote(repo_dir: Path, remote: str = "origin", branch: str = "main") -> Tuple[bool, str]:
-    """Pull changes from a remote branch.
-
-    Args:
-        repo_dir: Path to the git repository
-        remote: Remote name (default: origin)
-        branch: Branch name (default: main)
-
-    Returns:
-        Tuple of (success, message).
-    """
-    result = _run_git_command(repo_dir, "pull", remote, branch, check=False)
-
-    if result.returncode == 0:
-        return True, "Pull successful"
-
-    error_msg = result.stderr.strip() or result.stdout.strip()
-    return False, error_msg
-
-
-def push_to_remote(repo_dir: Path, remote: str = "origin", branch: Optional[str] = None) -> Tuple[bool, str]:
-    """Push changes to a remote branch.
-
-    Args:
-        repo_dir: Path to the git repository
-        remote: Remote name (default: origin)
-        branch: Branch name (default: current branch)
-
-    Returns:
-        Tuple of (success, message).
-    """
-    if branch is None:
-        branch = get_current_branch(repo_dir)
-
-    result = _run_git_command(repo_dir, "push", remote, branch, check=False)
-
-    if result.returncode == 0:
-        return True, "Push successful"
-
-    error_msg = result.stderr.strip() or result.stdout.strip()
-    return False, error_msg

--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -21,6 +21,7 @@ from auto_slopp.utils.git_operations import (
     delete_branch,
     get_current_branch,
     has_changes,
+    sanitize_branch_name,
 )
 from auto_slopp.utils.github_operations import (
     close_issue,
@@ -230,7 +231,7 @@ class GitHubIssueWorker(Worker):
         }
 
         try:
-            branch_name = f"ai/issue-{issue_number}-{issue_title[:30].replace(' ', '-').lower()}"
+            branch_name = f"ai/issue-{issue_number}-{sanitize_branch_name(issue_title[:30].lower())}"
             instructions = self._build_instructions(issue_title, issue_body, comment_texts, branch_name=branch_name)
 
             if self.dry_run:

--- a/tests/test_github_issue_worker.py
+++ b/tests/test_github_issue_worker.py
@@ -285,3 +285,71 @@ class TestGitHubIssueWorker:
                 assert result["success"] is True
                 assert result["issues_processed"] == 1
                 assert result["issue_results"][0]["issue_number"] == 1
+
+    def test_branch_name_sanitization(self):
+        """Test that branch names are properly sanitized from issue titles."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            test_cases = [
+                {"title": "Fix bug", "expected": "ai/issue-1-fix-bug"},
+                {"title": "Fix: bug", "expected": "ai/issue-2-fix-bug"},
+                {
+                    "title": "Feature: Add new functionality",
+                    "expected": "ai/issue-3-feature-add-new-functio",
+                },
+                {
+                    "title": "Issue with:colon",
+                    "expected": "ai/issue-4-issue-with-colon",
+                },
+                {
+                    "title": "Issue with?question",
+                    "expected": "ai/issue-5-issue-with-question",
+                },
+                {
+                    "title": "Issue with*asterisk",
+                    "expected": "ai/issue-6-issue-with-asterisk",
+                },
+                {
+                    "title": "Issue with[brackets]",
+                    "expected": "ai/issue-7-issue-with-brackets",
+                },
+                {
+                    "title": "Issue\\with\\backslash",
+                    "expected": "ai/issue-8-issue-with-backslash",
+                },
+                {
+                    "title": "  Issue with spaces  ",
+                    "expected": "ai/issue-9-issue-with-spaces",
+                },
+                {
+                    "title": "Issue---with---dashes",
+                    "expected": "ai/issue-10-issue-with-dashes",
+                },
+            ]
+
+            for i, test_case in enumerate(test_cases, start=1):
+                issue = {
+                    "number": i,
+                    "title": test_case["title"],
+                    "body": "Test body",
+                    "url": f"https://github.com/test/repo/issues/{i}",
+                }
+
+                with patch("auto_slopp.workers.github_issue_worker.get_open_issues") as mock_issues:
+                    mock_issues.return_value = [issue]
+
+                    result = worker.run(repo_path)
+
+                    assert result["success"] is True
+                    assert result["issues_processed"] == 1
+
+                    from auto_slopp.utils.git_operations import sanitize_branch_name
+
+                    sanitized_title = sanitize_branch_name(test_case["title"][:30].lower())
+                    expected_branch = f"ai/issue-{i}-{sanitized_title}"
+
+                    assert result["issue_results"][0]["issue_title"] == test_case["title"]


### PR DESCRIPTION
Closes #199

Here ist the Output of the logs

<b>ERROR</b> (auto_slopp.utils.git_operations)
Message: Failed to create branch 'ai/issue-30-language:-de' in BrueterApp: fatal: 'ai/issue-30-language:-de' is not a valid branch name.
Time: 2026-03-01 07:17:12,648
<b>WARNING</b> (auto_slopp.workers.GitHubIssueWorker)
Message: Failed to process issue #30: Failed to create branch ai/issue-30-language:-de
Time: 2026-03-01 07:17:12,780