### PR TITLE
Prworker pushes to early

### DIFF
--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -152,10 +152,6 @@ class PRWorker(Worker):
                         result["error"] = f"Failed to fix merge conflicts: {fix_result.get('error', 'Unknown error')}"
                         continue
 
-                if not self._push_branch(repo_dir, branch):
-                    result["error"] = f"Failed to push branch {branch}"
-                    continue
-
                 test_result = self._run_tests(repo_dir)
                 result["test_results"].append(
                     {
@@ -166,6 +162,8 @@ class PRWorker(Worker):
                     }
                 )
 
+                tests_successful = test_result["success"]
+
                 if not test_result["success"]:
                     cli_tool = settings.cli_command
                     self.logger.info(f"Tests failed for {branch} in {repo_dir.name}, using {cli_tool} to fix")
@@ -173,15 +171,19 @@ class PRWorker(Worker):
                     if fix_result["success"]:
                         result["tests_fixed"] = True
                         verify_result = self._run_tests(repo_dir)
+                        tests_successful = verify_result["success"]
                         result["test_results"][-1]["fix_success"] = verify_result["success"]
                         result["test_results"][-1]["fix_output"] = verify_result.get("output", "")
-                        if verify_result["success"] and not self._push_branch(repo_dir, branch):
-                            self.logger.warning(f"Failed to push branch {branch} after fixing tests")
                     else:
+                        tests_successful = False
                         result["test_results"][-1]["fix_success"] = False
                         result["test_results"][-1]["fix_error"] = fix_result.get("error", "Unknown fix error")
                 else:
                     result["test_results"][-1]["fix_success"] = True
+
+                if tests_successful and not self._push_branch(repo_dir, branch):
+                    result["error"] = f"Failed to push branch {branch}"
+                    continue
 
             result["success"] = True
 

--- a/tests/test_pr_worker.py
+++ b/tests/test_pr_worker.py
@@ -1,0 +1,52 @@
+"""Tests for PRWorker."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from auto_slopp.workers.pr_worker import PRWorker
+
+
+class TestPRWorker:
+    """Tests for PRWorker push behavior."""
+
+    def test_pushes_once_when_tests_pass_without_fix(self):
+        """PRWorker should push only once when tests pass immediately."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        with (
+            patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
+            patch.object(worker, "_checkout_branch", return_value=True),
+            patch.object(worker, "_update_branch_with_main", return_value=True),
+            patch.object(worker, "_run_tests", return_value={"success": True, "output": "", "error": None}),
+            patch.object(worker, "_push_branch", return_value=True) as mock_push_branch,
+        ):
+            result = worker._process_repository(repo_dir)
+
+        assert result["success"] is True
+        assert mock_push_branch.call_count == 1
+
+    def test_pushes_once_when_tests_pass_after_fix(self):
+        """PRWorker should push only once after tests are fixed and pass."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        with (
+            patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
+            patch.object(worker, "_checkout_branch", return_value=True),
+            patch.object(worker, "_update_branch_with_main", return_value=True),
+            patch.object(
+                worker,
+                "_run_tests",
+                side_effect=[
+                    {"success": False, "output": "", "error": "failed"},
+                    {"success": True, "output": "", "error": None},
+                ],
+            ),
+            patch.object(worker, "_fix_tests_with_cli", return_value={"success": True}),
+            patch.object(worker, "_push_branch", return_value=True) as mock_push_branch,
+        ):
+            result = worker._process_repository(repo_dir)
+
+        assert result["success"] is True
+        assert mock_push_branch.call_count == 1


### PR DESCRIPTION
Closes #217

The prworker pushes right after merging the furrent Main and again after ensuring Tests are successful. It should only Push once to prevent unnecessary triggers to GitHub Pipelines 