### PR TITLE
Add name to cli configuration

### DIFF
--- a/src/auto_slopp/utils/cli_executor.py
+++ b/src/auto_slopp/utils/cli_executor.py
@@ -33,16 +33,17 @@ def _check_cooldowns(working_dir: Path) -> None:
     for index, config in enumerate(settings.cli_configurations):
         state = _get_cli_state(index)
         if not state["active"] and now >= state["cooldown_until"]:
-            logger.info(f"Checking if CLI tool at index {index} has recovered...")
+            logger.info(f"Checking if CLI tool {config.name} has recovered...")
             c_dict = {
                 "cli_command": config.cli_command,
                 "cli_args": list(config.cli_args),
+                "name": config.name,
             }
             if _probe_configuration(c_dict, working_dir):
-                logger.info(f"CLI tool at index {index} successfully recovered.")
+                logger.info(f"CLI tool {config.name} successfully recovered.")
                 state["active"] = True
             else:
-                logger.warning(f"CLI tool at index {index} still timing out. Resetting cooldown.")
+                logger.warning(f"CLI tool {config.name} still timing out. Resetting cooldown.")
                 state["cooldown_until"] = now + config.cooldown_seconds
 
 
@@ -79,6 +80,7 @@ def _get_cli_configurations() -> List[Dict[str, Any]]:
         {
             "cli_command": config.cli_command,
             "cli_args": list(config.cli_args),
+            "name": config.name,
         }
         for config in settings.cli_configurations
     ]
@@ -300,7 +302,7 @@ def run_cli_executor(
             additional_instructions=additional_instructions,
         )
 
-        logger.info(f"Using CLI configuration index: {config_index} ({cli_command}) for task {task_name}")
+        logger.info(f"Using CLI configuration: {config['name']} for task {task_name}")
         result = _execute_command(
             cli_command=cli_command,
             cmd=cmd,
@@ -312,7 +314,7 @@ def run_cli_executor(
         final_result = result
 
         if not result.get("success", False):
-            logger.warning(f"Error on configuration index {config_index}, placing in cooldown")
+            logger.warning(f"Error on configuration {config['name']}, placing in cooldown")
             state["active"] = False
             state["cooldown_until"] = time.time() + settings.cli_configurations[config_index].cooldown_seconds
             continue

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -42,6 +42,10 @@ class CLIConfiguration(BaseModel):
         default=300,
         description="Cooldown time in seconds if the tool encounters errors",
     )
+    name: str = Field(
+        default="",
+        description="Human-readable name for this CLI configuration",
+    )
 
 
 class Settings(BaseSettings):
@@ -118,11 +122,13 @@ class Settings(BaseSettings):
                 cli_command="gemini",
                 cli_args=["--yolo", "--model", "gemini-3.1-pro-preview", "-p"],
                 capability=7,
+                name="gemini gemini-3.1-pro-preview",
             ),
             CLIConfiguration(
                 cli_command="codex",
                 cli_args=["--dangerously-bypass-approvals-and-sandbox", "exec"],
                 capability=8,
+                name="codex",
             ),
             CLIConfiguration(
                 cli_command="opencode",
@@ -134,6 +140,7 @@ class Settings(BaseSettings):
                     "run",
                 ],
                 capability=10,
+                name="opencode glm-5",
             ),
             CLIConfiguration(
                 cli_command="opencode",
@@ -145,6 +152,7 @@ class Settings(BaseSettings):
                     "run",
                 ],
                 capability=6,
+                name="opencode glm-4.7",
             ),
             CLIConfiguration(
                 cli_command="opencode",
@@ -156,6 +164,7 @@ class Settings(BaseSettings):
                     "run",
                 ],
                 capability=1,
+                name="opencode glm-4.7-flash",
             ),
         ],
         description=(
@@ -186,8 +195,8 @@ class Settings(BaseSettings):
     task_difficulties: Dict[str, TaskRating] = Field(
         default={
             "github_issue": TaskRating(min_rating=7, max_rating=10, recommended_rating=10),
-            "pr_review": TaskRating(min_rating=0, max_rating=10, recommended_rating=5), # fix tests
-            "git_checkout": TaskRating(min_rating=0, max_rating=10, recommended_rating=2), # merge conflict
+            "pr_review": TaskRating(min_rating=0, max_rating=10, recommended_rating=5),  # fix tests
+            "git_checkout": TaskRating(min_rating=0, max_rating=10, recommended_rating=2),  # merge conflict
             "default": TaskRating(min_rating=0, max_rating=10, recommended_rating=5),
         },
         description="Difficulty ratings for various tasks (0-10)",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -148,13 +148,15 @@ class TestSettings:
     def test_cli_configurations_default(self):
         """Test default tiered CLI configurations."""
         test_settings = Settings()
-        assert len(test_settings.cli_configurations) == 4
+        assert len(test_settings.cli_configurations) == 5
         assert test_settings.cli_configurations[0].cli_command == "gemini"
         assert test_settings.cli_configurations[1].cli_command == "codex"
         assert test_settings.cli_configurations[2].cli_command == "opencode"
-        assert "glm-4.7" in str(test_settings.cli_configurations[2].cli_args)
+        assert "glm-5" in str(test_settings.cli_configurations[2].cli_args)
         assert test_settings.cli_configurations[3].cli_command == "opencode"
-        assert "glm-4.7-flash" in str(test_settings.cli_configurations[3].cli_args)
+        assert "glm-4.7" in str(test_settings.cli_configurations[3].cli_args)
+        assert test_settings.cli_configurations[4].cli_command == "opencode"
+        assert "glm-4.7-flash" in str(test_settings.cli_configurations[4].cli_args)
 
     def test_cli_configurations_env_override(self):
         """Test overriding CLI configurations via environment variable."""


### PR DESCRIPTION
Closes #233

Add a name field to the CliConfiguration and print out the name instead of the index in the logs of the cli_executor.
For the currently defined CliConfigurations set the name to "<cli_command> <model name>".