### PR TITLE
PRWorker restriction

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -59,7 +59,6 @@ def _run_gh_command(
         env["GH_TOKEN"] = env["GITHUB_TOKEN"]
 
     try:
-
         result = subprocess.run(
             ["gh", *args],
             cwd=repo_dir,
@@ -301,14 +300,14 @@ def create_pull_request(
         return None
 
 
-def get_open_pr_branches(repo_dir: Path) -> List[str]:
-    """Get list of branches from open PRs in the repository.
+def get_open_prs(repo_dir: Path) -> List[Dict[str, Any]]:
+    """Get list of open PRs in the repository with full information.
 
     Args:
         repo_dir: Path to the git repository
 
     Returns:
-        List of branch names from open PRs.
+        List of dictionaries containing PR information (headRefName, author, etc).
 
     Raises:
         GitHubOperationError: If gh command fails
@@ -319,7 +318,7 @@ def get_open_pr_branches(repo_dir: Path) -> List[str]:
             "pr",
             "list",
             "--state=open",
-            "--json=headRefName",
+            "--json=headRefName,author,number,title",
             check=False,
         )
 
@@ -335,9 +334,7 @@ def get_open_pr_branches(repo_dir: Path) -> List[str]:
             return []
 
         prs = json.loads(result.stdout)
-        branches = [pr["headRefName"] for pr in prs]
-
-        return branches
+        return prs
 
     except GitHubOperationError as e:
         logger.error(f"Error getting PRs from {repo_dir.name}: {str(e)}")
@@ -348,6 +345,23 @@ def get_open_pr_branches(repo_dir: Path) -> List[str]:
     except Exception as e:
         logger.error(f"Unexpected error getting PRs from {repo_dir.name}: {str(e)}")
         return []
+
+
+def get_open_pr_branches(repo_dir: Path) -> List[str]:
+    """Get list of branches from open PRs in the repository.
+
+    Args:
+        repo_dir: Path to the git repository
+
+    Returns:
+        List of branch names from open PRs.
+
+    Raises:
+        GitHubOperationError: If gh command fails
+    """
+    prs = get_open_prs(repo_dir)
+    branches = [pr["headRefName"] for pr in prs]
+    return branches
 
 
 def get_pr_for_branch(repo_dir: Path, branch: str) -> Optional[Dict[str, Any]]:

--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -15,7 +15,7 @@ from auto_slopp.utils.git_operations import (
     merge_main_into_branch,
     push_branch,
 )
-from auto_slopp.utils.github_operations import get_open_pr_branches
+from auto_slopp.utils.github_operations import get_open_prs
 from auto_slopp.utils.repository_utils import discover_repositories, validate_repository
 from auto_slopp.worker import Worker
 from settings.main import settings
@@ -194,15 +194,30 @@ class PRWorker(Worker):
         return result
 
     def _get_open_pr_branches(self, repo_dir: Path) -> List[str]:
-        """Get list of branches from open PRs in the repository.
+        """Get list of branches from open PRs in the repository, filtered by allowed creator.
 
         Args:
             repo_dir: Path to the repository directory
 
         Returns:
-            List of branch names from open PRs
+            List of branch names from open PRs created by allowed creator
         """
-        return get_open_pr_branches(repo_dir)
+        prs = get_open_prs(repo_dir)
+        allowed_creator = settings.github_issue_worker_allowed_creator
+
+        filtered_branches = []
+        for pr in prs:
+            author = pr.get("author", {})
+            author_login = author.get("login", "") if author else ""
+
+            if author_login == allowed_creator:
+                filtered_branches.append(pr["headRefName"])
+            else:
+                self.logger.info(
+                    f"Skipping PR #{pr.get('number')} '{pr.get('title')}': " f"not created by '{allowed_creator}'"
+                )
+
+        return filtered_branches
 
     def _checkout_branch(self, repo_dir: Path, branch: str) -> bool:
         """Checkout a specific branch in the repository.

--- a/tests/test_pr_worker.py
+++ b/tests/test_pr_worker.py
@@ -1,7 +1,7 @@
 """Tests for PRWorker."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from auto_slopp.workers.pr_worker import PRWorker
 
@@ -18,7 +18,11 @@ class TestPRWorker:
             patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
             patch.object(worker, "_checkout_branch", return_value=True),
             patch.object(worker, "_update_branch_with_main", return_value=True),
-            patch.object(worker, "_run_tests", return_value={"success": True, "output": "", "error": None}),
+            patch.object(
+                worker,
+                "_run_tests",
+                return_value={"success": True, "output": "", "error": None},
+            ),
             patch.object(worker, "_push_branch", return_value=True) as mock_push_branch,
         ):
             result = worker._process_repository(repo_dir)
@@ -50,3 +54,129 @@ class TestPRWorker:
 
         assert result["success"] is True
         assert mock_push_branch.call_count == 1
+
+    def test_filters_prs_by_allowed_creator(self):
+        """Test that PRWorker only processes PRs from allowed creator."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        mock_prs = [
+            {
+                "headRefName": "feature-1",
+                "author": {"login": "MelvinKl"},
+                "number": 1,
+                "title": "Feature 1",
+            },
+            {
+                "headRefName": "feature-2",
+                "author": {"login": "other-user"},
+                "number": 2,
+                "title": "Feature 2",
+            },
+            {
+                "headRefName": "feature-3",
+                "author": {"login": "MelvinKl"},
+                "number": 3,
+                "title": "Feature 3",
+            },
+        ]
+
+        with patch("auto_slopp.workers.pr_worker.get_open_prs", return_value=mock_prs):
+            with patch("auto_slopp.workers.pr_worker.settings") as mock_settings:
+                mock_settings.github_issue_worker_allowed_creator = "MelvinKl"
+                branches = worker._get_open_pr_branches(repo_dir)
+
+        assert len(branches) == 2
+        assert "feature-1" in branches
+        assert "feature-3" in branches
+        assert "feature-2" not in branches
+
+    def test_skips_all_prs_when_none_from_allowed_creator(self):
+        """Test that PRWorker skips all PRs when none are from allowed creator."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        mock_prs = [
+            {
+                "headRefName": "feature-1",
+                "author": {"login": "user1"},
+                "number": 1,
+                "title": "Feature 1",
+            },
+            {
+                "headRefName": "feature-2",
+                "author": {"login": "user2"},
+                "number": 2,
+                "title": "Feature 2",
+            },
+        ]
+
+        with patch("auto_slopp.workers.pr_worker.get_open_prs", return_value=mock_prs):
+            with patch("auto_slopp.workers.pr_worker.settings") as mock_settings:
+                mock_settings.github_issue_worker_allowed_creator = "MelvinKl"
+                branches = worker._get_open_pr_branches(repo_dir)
+
+        assert len(branches) == 0
+
+    def test_processes_all_prs_from_allowed_creator(self):
+        """Test that PRWorker processes all PRs when all are from allowed creator."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        mock_prs = [
+            {
+                "headRefName": "feature-1",
+                "author": {"login": "MelvinKl"},
+                "number": 1,
+                "title": "Feature 1",
+            },
+            {
+                "headRefName": "feature-2",
+                "author": {"login": "MelvinKl"},
+                "number": 2,
+                "title": "Feature 2",
+            },
+        ]
+
+        with patch("auto_slopp.workers.pr_worker.get_open_prs", return_value=mock_prs):
+            with patch("auto_slopp.workers.pr_worker.settings") as mock_settings:
+                mock_settings.github_issue_worker_allowed_creator = "MelvinKl"
+                branches = worker._get_open_pr_branches(repo_dir)
+
+        assert len(branches) == 2
+        assert "feature-1" in branches
+        assert "feature-2" in branches
+
+    def test_handles_pr_without_author(self):
+        """Test that PRWorker handles PRs with missing author information."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        mock_prs = [
+            {
+                "headRefName": "feature-1",
+                "author": None,
+                "number": 1,
+                "title": "Feature 1",
+            },
+            {
+                "headRefName": "feature-2",
+                "author": {},
+                "number": 2,
+                "title": "Feature 2",
+            },
+            {
+                "headRefName": "feature-3",
+                "author": {"login": "MelvinKl"},
+                "number": 3,
+                "title": "Feature 3",
+            },
+        ]
+
+        with patch("auto_slopp.workers.pr_worker.get_open_prs", return_value=mock_prs):
+            with patch("auto_slopp.workers.pr_worker.settings") as mock_settings:
+                mock_settings.github_issue_worker_allowed_creator = "MelvinKl"
+                branches = worker._get_open_pr_branches(repo_dir)
+
+        assert len(branches) == 1
+        assert "feature-3" in branches


### PR DESCRIPTION
Closes #235

The PRWorker should have the same restriction as thew GithubIusseWorker that he only works on PRs opened by "github_issue_worker_allowed_creator".