### PR TITLE
Enhance the planning of the githubissueworker

### DIFF
--- a/src/auto_slopp/workers/github_issue_worker.py
+++ b/src/auto_slopp/workers/github_issue_worker.py
@@ -540,13 +540,29 @@ class GitHubIssueWorker(Worker):
                 "If there is a branch/PR linked in the issue use this branch.\n"
             )
 
+        plan_text = """
+Plan:
+1. Understand the requirements by analyzing the issue title and description
+2. Explore the codebase to understand the current implementation
+3. Identify components that can be reused
+4. Design a solution that is simple and focused
+5. Write or update tests for the changes
+6. Implement the solution
+7. Run 'make lint' to ensure code quality
+8. Run 'make test' to verify all tests pass
+9. Commit the changes with a clear commit message
+10. Push the changes to the remote branch
+"""
+
         return (
             f"{branch_instruction}"
             f"Implement the following:\n"
             f"Title: {issue_title}\n"
             f"Description:{body_text}\n"
             f"{comments_text}\n"
-            f"Keep your implementation simple. Only implement what is required. Check if there are components you can reuse. "
+            f"{plan_text}\n"
+            f"Keep your implementation simple. Only implement what is required. "
+            f"Check if there are components you can reuse. "
             f"Ensure that 'make test' runs successful. Only push if ALL tests are successful. "
             f"Check if you need to update the README.md."
         )

--- a/tests/test_github_issue_worker.py
+++ b/tests/test_github_issue_worker.py
@@ -253,6 +253,21 @@ class TestGitHubIssueWorker:
         assert "Test issue" in instructions
         assert "ai/" in instructions
 
+    def test_build_instructions_includes_plan(self):
+        """Test that instructions include a structured plan."""
+        worker = GitHubIssueWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Test issue", "Test body")
+        assert "Plan:" in instructions
+        assert "1." in instructions
+        assert "2." in instructions
+        assert "Understand the requirements" in instructions
+        assert "Explore the codebase" in instructions
+        assert "make lint" in instructions
+        assert "make test" in instructions
+        assert "Commit the changes" in instructions
+        assert "Push the changes" in instructions
+
     def test_create_error_result(self):
         """Test error result creation."""
         worker = GitHubIssueWorker(dry_run=True)


### PR DESCRIPTION
Closes #244

I'm not sure what the githubissueworker is currently planning, but those plans are not helpful.
A plan could look like this:
 - Check what the githubissueworker is currently planning
 - Find flaws in the current implementation
 - Come up with an improvement
 - Check if any of parts required for the improvement are already implemented elsewhere and can be reused
 - Update tests
 - Implement improvements
 - Ensure linting is successfull
 - Ensure testing is successfull
 - Commit changes
