### PR TITLE
OpenProject Worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,42 @@ AUTO_SLOPP_GITHUB_ISSUE_WORKER_REQUIRED_LABEL=ai
 # Issues created by this user will be processed even without the required label
 AUTO_SLOPP_GITHUB_ISSUE_WORKER_ALLOWED_CREATOR=MelvinKl
 
+# =============================================================================
+# OPENPROJECT WORKER CONFIGURATION
+# =============================================================================
+
+# Enable OpenProject worker integration (default: False)
+# Set to 'true' or '1' to enable OpenProject task processing
+AUTO_SLOPP_OPENPROJECT_ENABLED=false
+
+# Base URL for OpenProject instance (required if OpenProject enabled)
+# Example: https://openproject.example.com
+AUTO_SLOPP_OPENPROJECT_URL=
+
+# API token for OpenProject authentication (required if OpenProject enabled)
+# Get this from your OpenProject user settings > API tokens
+AUTO_SLOPP_OPENPROJECT_API_TOKEN=
+
+# User ID to filter tasks assigned to (auto-slopper user)
+# Only tasks assigned to this user will be processed
+AUTO_SLOPP_OPENPROJECT_ASSIGNED_USER_ID=0
+
+# Default status ID for new tasks (default: 1)
+AUTO_SLOPP_OPENPROJECT_DEFAULT_STATUS_ID=1
+
+# Status ID to set when task is in progress (default: 2)
+AUTO_SLOPP_OPENPROJECT_IN_PROGRESS_STATUS_ID=2
+
+# Optional prefix for project identifiers when creating new projects
+# Example: 'dev-' would create projects with identifiers like 'dev-myproject'
+AUTO_SLOPP_OPENPROJECT_PROJECT_PREFIX=
+
+# Automatically create OpenProject projects if they don't exist (default: True)
+AUTO_SLOPP_OPENPROJECT_CREATE_PROJECTS=true
+
+# Default work package type ID for new tasks (default: 1, usually "Task")
+AUTO_SLOPP_OPENPROJECT_TASK_TYPE_ID=1
+
 # Optional CLI overrides (leave commented out to use slopmachine preset defaults)
 # AUTO_SLOPP_CLI_COMMAND=opencode
 # AUTO_SLOPP_CLI_ARGS='["--agent", "openagent", "run"]'

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ credentials.*
 
 # uv specific
 .uv_cache/
+
+# Ralph plan files
+.ralph/

--- a/README.md
+++ b/README.md
@@ -399,6 +399,14 @@ AUTO_SLOPP_TELEGRAM_CHAT_ID=your_chat_id
 AUTO_SLOPP_TELEGRAM_TIMEOUT=60.0
 AUTO_SLOPP_TELEGRAM_RETRY_ATTEMPTS=5
 AUTO_SLOPP_TELEGRAM_PARSE_MODE=HTML
+
+# OpenProject integration (optional)
+AUTO_SLOPP_OPENPROJECT_ENABLED=true
+AUTO_SLOPP_OPENPROJECT_URL=https://openproject.example.com
+AUTO_SLOPP_OPENPROJECT_API_TOKEN=your_api_token
+AUTO_SLOPP_OPENPROJECT_ASSIGNED_USER_ID=5
+AUTO_SLOPP_OPENPROJECT_IN_PROGRESS_STATUS_ID=7
+AUTO_SLOPP_OPENPROJECT_CREATE_PROJECTS=true
 ```
 
 ## Creating Worker Implementations
@@ -486,7 +494,7 @@ To disable specific workers, set the `AUTO_SLOPP_WORKERS_DISABLED` variable in y
 AUTO_SLOPP_WORKERS_DISABLED='["GitHubIssueWorker", "PRWorker"]'
 
 # Disable all workers
-AUTO_SLOPP_WORKERS_DISABLED='["GitHubIssueWorker", "PRWorker", "StaleBranchCleanupWorker"]'
+AUTO_SLOPP_WORKERS_DISABLED='["GitHubIssueWorker", "PRWorker", "StaleBranchCleanupWorker", "OpenProjectWorker"]'
 ```
 
 ## Available Workers
@@ -518,6 +526,50 @@ from auto_slopp.workers import StaleBranchCleanupWorker
 
 # Disable in AUTO_SLOPP_WORKERS_DISABLED
 # Returns: cleaned branches, deletion status
+```
+
+### OpenProjectWorker
+Processes tasks from OpenProject integration.
+```python
+from auto_slopp.workers import OpenProjectWorker
+
+# Requires OpenProject configuration (see below)
+# Returns: tasks processed, PRs created, work packages updated
+```
+
+The OpenProjectWorker:
+1. Matches GitHub repositories to OpenProject projects by name
+2. Creates OpenProject projects if they don't exist (configurable)
+3. Searches for open tasks assigned to a configured user
+4. Creates subtasks for the first open task
+5. Creates a branch linked to the task and executes subtasks
+6. Commits changes, pushes branch, and creates a PR
+7. Adds a comment to the OpenProject task and sets status to in progress
+
+#### OpenProject Configuration
+```bash
+# Enable OpenProject integration
+AUTO_SLOPP_OPENPROJECT_ENABLED=true
+
+# OpenProject instance URL and API token
+AUTO_SLOPP_OPENPROJECT_URL=https://openproject.example.com
+AUTO_SLOPP_OPENPROJECT_API_TOKEN=your_api_token
+
+# User ID to filter tasks assigned to (auto-slopper user)
+AUTO_SLOPP_OPENPROJECT_ASSIGNED_USER_ID=5
+
+# Status IDs for task workflow
+AUTO_SLOPP_OPENPROJECT_DEFAULT_STATUS_ID=1
+AUTO_SLOPP_OPENPROJECT_IN_PROGRESS_STATUS_ID=7
+
+# Optional prefix for project identifiers
+AUTO_SLOPP_OPENPROJECT_PROJECT_PREFIX=auto_
+
+# Auto-create projects if they don't exist
+AUTO_SLOPP_OPENPROJECT_CREATE_PROJECTS=true
+
+# Default work package type ID
+AUTO_SLOPP_OPENPROJECT_TASK_TYPE_ID=1
 ```
 
 ## API Reference
@@ -627,6 +679,7 @@ Auto-slopp/
 │   │   ├── workers/             # Worker implementations
 │   │   │   ├── pr_worker.py
 │   │   │   ├── github_issue_worker.py
+│   │   │   ├── openproject_worker.py
 │   │   │   └── stale_branch_cleanup_worker.py
 │   │   └── utils/               # Utility modules
 │   │       ├── git_operations.py

--- a/docs/openproject_worker_design.md
+++ b/docs/openproject_worker_design.md
@@ -1,0 +1,243 @@
+# OpenProject Worker Design
+
+## Overview
+
+The OpenProject Worker automates task processing by integrating OpenProject (project management) with GitHub repositories. It mirrors the GitHubIssueWorker pattern but sources tasks from OpenProject instead of GitHub Issues.
+
+## Architecture
+
+### Components to Reuse (No Changes Required)
+
+| Component | Module | Purpose |
+|-----------|--------|---------|
+| Worker base class | `auto_slopp.worker.Worker` | Abstract base for all workers |
+| Git operations | `auto_slopp.utils.git_operations` | Branch creation, checkout, push, sanitize |
+| GitHub operations | `auto_slopp.utils.github_operations` | PR creation, branch management |
+| CLI executor | `auto_slopp.utils.cli_executor` | Execute instructions with CLI tools |
+| Ralph loop | `auto_slopp.utils.ralph` | Step-based execution with plans |
+
+### New Components Required
+
+1. **OpenProject API Client** - `src/auto_slopp/utils/openproject_operations.py`
+2. **OpenProject Worker** - `src/auto_slopp/workers/openproject_worker.py`
+3. **Settings** - Add OpenProject configuration to `src/settings/main.py`
+
+## Workflow
+
+```
+For each GitHub repository:
+    │
+    ├─► Get/corresponding OpenProject project (by name match)
+    │   └─► Create project if not exists
+    │
+    ├─► Get open tasks assigned to configured user
+    │
+    └─► For first open task:
+        │
+        ├─► Create subtasks with detailed descriptions
+        │
+        ├─► Create branch: ai/op-{task_id}-{sanitized_subject}
+        │
+        ├─► Execute subtasks using Ralph loop
+        │   └─► Each subtask is a step in the plan
+        │
+        ├─► Commit and push changes
+        │
+        ├─► Create PR in GitHub
+        │
+        ├─► Add comment to OpenProject task
+        │
+        └─► Set task status to "in progress"
+```
+
+## OpenProject API Client Design
+
+### Required API Endpoints
+
+| Function | Endpoint | Purpose |
+|----------|----------|---------|
+| `get_projects()` | `/api/v3/projects` | List all projects |
+| `get_project_by_name()` | `/api/v3/projects?filters=[{"name":{"operator":"=","values":["name"]}}]` | Find project by name |
+| `create_project()` | `/api/v3/projects` | Create new project |
+| `get_work_packages()` | `/api/v3/projects/{id}/work_packages` | Get tasks for project |
+| `create_work_package()` | `/api/v3/projects/{id}/work_packages` | Create subtask |
+| `update_work_package()` | `/api/v3/work_packages/{id}` | Update task status |
+| `add_comment()` | `/api/v3/work_packages/{id}/activities` | Add comment to task |
+| `get_user()` | `/api/v3/users/{id}` | Get user info |
+
+### Data Structures
+
+```python
+# Work Package (Task) from OpenProject
+{
+    "id": int,
+    "subject": str,
+    "description": {"raw": str},
+    "status": {"id": int, "name": str},
+    "assignee": {"id": int, "name": str},
+    "project": {"id": int, "name": str},
+    "_links": {
+        "self": {"href": str},
+        "project": {"href": str}
+    }
+}
+
+# Project from OpenProject
+{
+    "id": int,
+    "name": str,
+    "identifier": str,
+    "_links": {
+        "self": {"href": str}
+    }
+}
+```
+
+## OpenProject Worker Design
+
+### Class Structure
+
+```python
+class OpenProjectWorker(Worker):
+    def __init__(
+        self,
+        timeout: int | None = None,
+        agent_args: List[str] | None = None,
+        dry_run: bool = False,
+    ):
+        # Initialize similar to GitHubIssueWorker
+        
+    def run(self, repo_path: Path) -> Dict[str, Any]:
+        # Main execution flow
+        
+    def _get_or_create_project(self, repo_name: str) -> Dict | None:
+        # Find or create OpenProject project
+        
+    def _get_open_tasks_for_user(self, project_id: int) -> List[Dict]:
+        # Get open tasks assigned to configured user
+        
+    def _create_subtasks(self, task: Dict, repo_dir: Path) -> List[Dict]:
+        # Generate subtasks based on parent task analysis
+        
+    def _process_single_task(self, repo_dir: Path, task: Dict) -> Dict[str, Any]:
+        # Process one task (create branch, execute, create PR)
+        
+    def _execute_with_ralph_loop(...) -> Dict[str, Any]:
+        # Execute subtasks as Ralph steps
+        
+    def _build_instructions(...) -> str:
+        # Build instructions for CLI executor
+```
+
+### Branch Naming Convention
+
+```
+ai/op-{task_id}-{sanitized_subject_30_chars}
+```
+
+Example: `ai/op-42-implement-user-authentication`
+
+## Settings Configuration
+
+### New Settings Fields
+
+```python
+# OpenProject Configuration
+openproject_url: str = Field(
+    default="",
+    description="Base URL for OpenProject instance (e.g., https://openproject.example.com)"
+)
+
+openproject_api_token: str = Field(
+    default="",
+    description="API token for OpenProject authentication"
+)
+
+openproject_assigned_user_id: int = Field(
+    default=0,
+    description="User ID to filter tasks assigned to (auto-slopper user)"
+)
+
+openproject_default_status_id: int = Field(
+    default=1,
+    description="Default status ID for new tasks"
+)
+
+openproject_in_progress_status_id: int = Field(
+    default=2,
+    description="Status ID to set when task is in progress"
+)
+
+openproject_project_prefix: str = Field(
+    default="",
+    description="Optional prefix for project identifiers"
+)
+```
+
+### Environment Variables
+
+```bash
+AUTO_SLOPP_OPENPROJECT_URL=https://openproject.example.com
+AUTO_SLOPP_OPENPROJECT_API_TOKEN=your_api_token
+AUTO_SLOPP_OPENPROJECT_ASSIGNED_USER_ID=5
+AUTO_SLOPP_OPENPROJECT_DEFAULT_STATUS_ID=1
+AUTO_SLOPP_OPENPROJECT_IN_PROGRESS_STATUS_ID=2
+```
+
+## Subtask Generation Strategy
+
+The worker will analyze the parent task and generate subtasks using the CLI tool with a structured prompt:
+
+```
+Analyze this task and create a breakdown of subtasks:
+- Task Subject: {subject}
+- Task Description: {description}
+
+Generate 3-7 subtasks that:
+1. Are specific and actionable
+2. Include mention of reusable components from the codebase
+3. Follow the standard development workflow
+4. Can be executed sequentially
+
+Format each subtask as a clear instruction.
+```
+
+## Error Handling
+
+- API failures: Log error, return empty list, continue to next repo
+- Project not found: Create project if configured, else skip
+- Branch creation failure: Log and skip task
+- PR creation failure: Log but continue, update OpenProject anyway
+- Ralph loop failure: Log error, don't mark task as in progress
+
+## Testing Strategy
+
+Similar to GitHubIssueWorker tests:
+1. Test initialization with various parameters
+2. Test with no tasks available
+3. Test dry run mode
+4. Test branch name sanitization
+5. Test error handling scenarios
+6. Test subtask generation
+7. Mock OpenProject API responses
+
+## Implementation Order
+
+1. Create `openproject_operations.py` with API client
+2. Add settings to `main.py`
+3. Create `openproject_worker.py`
+4. Add worker to `workers/__init__.py`
+5. Update `.env.example` with new settings
+6. Write tests in `tests/test_openproject_worker.py`
+7. Update `README.md` if needed
+
+## Differences from GitHubIssueWorker
+
+| Aspect | GitHubIssueWorker | OpenProjectWorker |
+|--------|-------------------|-------------------|
+| Task source | GitHub Issues | OpenProject Work Packages |
+| Task filter | By label and creator | By assignee and status |
+| Branch prefix | `ai/issue-` | `ai/op-` |
+| Subtask creation | N/A | Creates subtasks before execution |
+| Status update | Close issue | Set to "in progress" |
+| Project matching | Repository-based | Name match with OpenProject project |

--- a/src/auto_slopp/utils/openproject_operations.py
+++ b/src/auto_slopp/utils/openproject_operations.py
@@ -1,0 +1,504 @@
+"""OpenProject operations utilities for workers.
+
+This module provides pure functions for common OpenProject operations
+used across different workers via the OpenProject REST API.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from settings.main import settings
+
+logger = logging.getLogger(__name__)
+
+
+class OpenProjectOperationError(Exception):
+    """Exception raised when OpenProject operations fail."""
+
+    pass
+
+
+def _get_client() -> httpx.Client:
+    """Get an HTTP client configured for OpenProject API.
+
+    Returns:
+        Configured httpx.Client instance
+    """
+    headers = {
+        "Authorization": f"Bearer {settings.openproject_api_token}",
+        "Content-Type": "application/json",
+    }
+    return httpx.Client(
+        base_url=settings.openproject_url.rstrip("/"),
+        headers=headers,
+        timeout=30.0,
+    )
+
+
+def get_projects() -> List[Dict[str, Any]]:
+    """Get list of all projects from OpenProject.
+
+    Returns:
+        List of dictionaries containing project information.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get("/api/v3/projects")
+            response.raise_for_status()
+            data = response.json()
+            return data.get("_embedded", {}).get("elements", [])
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get projects from OpenProject: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error getting projects: {e}")
+        return []
+
+
+def get_project_by_identifier(identifier: str) -> Optional[Dict[str, Any]]:
+    """Get a project by its identifier.
+
+    Args:
+        identifier: Project identifier (usually matches repo name)
+
+    Returns:
+        Project dictionary or None if not found.
+    """
+    try:
+        with _get_client() as client:
+            filters = f'[["identifier","=","{identifier}"]]'
+            response = client.get("/api/v3/projects", params={"filters": filters})
+            response.raise_for_status()
+            data = response.json()
+            elements = data.get("_embedded", {}).get("elements", [])
+            return elements[0] if elements else None
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get project {identifier}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error getting project {identifier}: {e}")
+        return None
+
+
+def get_project_by_name(name: str) -> Optional[Dict[str, Any]]:
+    """Get a project by its name.
+
+    Args:
+        name: Project name
+
+    Returns:
+        Project dictionary or None if not found.
+    """
+    try:
+        with _get_client() as client:
+            filters = f'[["name","=","{name}"]]'
+            response = client.get("/api/v3/projects", params={"filters": filters})
+            response.raise_for_status()
+            data = response.json()
+            elements = data.get("_embedded", {}).get("elements", [])
+            return elements[0] if elements else None
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get project by name {name}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error getting project by name {name}: {e}")
+        return None
+
+
+def create_project(
+    name: str,
+    identifier: str,
+    description: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a new project in OpenProject.
+
+    Args:
+        name: Project name
+        identifier: Project identifier (used in URLs)
+        description: Optional project description
+
+    Returns:
+        Created project dictionary or None if failed.
+    """
+    try:
+        with _get_client() as client:
+            payload: Dict[str, Any] = {
+                "name": name,
+                "identifier": identifier,
+            }
+            if description:
+                payload["description"] = {"raw": description}
+
+            response = client.post("/api/v3/projects", json=payload)
+            response.raise_for_status()
+            project = response.json()
+            logger.info(f"Created OpenProject project: {name} ({identifier})")
+            return project
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to create project {name}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error creating project {name}: {e}")
+        return None
+
+
+def get_work_packages(
+    project_id: int,
+    assigned_to_user_id: Optional[int] = None,
+    status_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Get work packages (tasks) for a project.
+
+    Args:
+        project_id: OpenProject project ID
+        assigned_to_user_id: Filter by assigned user ID
+        status_id: Filter by status ID
+
+    Returns:
+        List of work package dictionaries.
+    """
+    try:
+        with _get_client() as client:
+            filters_list = []
+            if assigned_to_user_id:
+                filters_list.append(["assigned_to_id", "=", str(assigned_to_user_id)])
+            if status_id:
+                filters_list.append(["status_id", "=", str(status_id)])
+
+            filters = str(filters_list) if filters_list else "[]"
+            params = {"filters": filters}
+
+            response = client.get(f"/api/v3/projects/{project_id}/work_packages", params=params)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("_embedded", {}).get("elements", [])
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get work packages for project {project_id}: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error getting work packages: {e}")
+        return []
+
+
+def get_open_work_packages(
+    project_id: int,
+    assigned_to_user_id: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Get open work packages (tasks) for a project.
+
+    Open tasks are those not in a "closed" state.
+
+    Args:
+        project_id: OpenProject project ID
+        assigned_to_user_id: Filter by assigned user ID
+
+    Returns:
+        List of open work package dictionaries.
+    """
+    return get_work_packages(
+        project_id=project_id,
+        assigned_to_user_id=assigned_to_user_id,
+        status_id=None,
+    )
+
+
+def get_work_package(work_package_id: int) -> Optional[Dict[str, Any]]:
+    """Get a single work package by ID.
+
+    Args:
+        work_package_id: Work package ID
+
+    Returns:
+        Work package dictionary or None if not found.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get(f"/api/v3/work_packages/{work_package_id}")
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get work package {work_package_id}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error getting work package {work_package_id}: {e}")
+        return None
+
+
+def create_work_package(
+    project_id: int,
+    subject: str,
+    description: Optional[str] = None,
+    type_id: Optional[int] = None,
+    parent_id: Optional[int] = None,
+    assignee_id: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a new work package (task) in a project.
+
+    Args:
+        project_id: OpenProject project ID
+        subject: Work package subject/title
+        description: Optional description (raw markdown)
+        type_id: Work package type ID (e.g., Task, Feature, Bug)
+        parent_id: Parent work package ID for subtasks
+        assignee_id: User ID to assign the task to
+
+    Returns:
+        Created work package dictionary or None if failed.
+    """
+    try:
+        with _get_client() as client:
+            payload: Dict[str, Any] = {
+                "subject": subject,
+                "_links": {
+                    "project": {"href": f"/api/v3/projects/{project_id}"},
+                },
+            }
+
+            if description:
+                payload["description"] = {"raw": description}
+
+            if type_id:
+                payload["_links"]["type"] = {"href": f"/api/v3/types/{type_id}"}
+
+            if parent_id:
+                payload["_links"]["parent"] = {"href": f"/api/v3/work_packages/{parent_id}"}
+
+            if assignee_id:
+                payload["_links"]["assignee"] = {"href": f"/api/v3/users/{assignee_id}"}
+
+            response = client.post(
+                f"/api/v3/projects/{project_id}/work_packages",
+                json=payload,
+            )
+            response.raise_for_status()
+            wp = response.json()
+            logger.info(f"Created work package: {subject}")
+            return wp
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to create work package {subject}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error creating work package {subject}: {e}")
+        return None
+
+
+def create_subtask(
+    parent_work_package_id: int,
+    project_id: int,
+    subject: str,
+    description: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a subtask under a parent work package.
+
+    Args:
+        parent_work_package_id: Parent work package ID
+        project_id: OpenProject project ID
+        subject: Subtask subject/title
+        description: Optional description
+
+    Returns:
+        Created work package dictionary or None if failed.
+    """
+    return create_work_package(
+        project_id=project_id,
+        subject=subject,
+        description=description,
+        parent_id=parent_work_package_id,
+    )
+
+
+def update_work_package(
+    work_package_id: int,
+    lock_version: int,
+    status_id: Optional[int] = None,
+    assignee_id: Optional[int] = None,
+    description: Optional[str] = None,
+    subject: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Update a work package.
+
+    Args:
+        work_package_id: Work package ID to update
+        lock_version: Current lock version (required for optimistic locking)
+        status_id: New status ID
+        assignee_id: New assignee user ID
+        description: New description
+        subject: New subject
+
+    Returns:
+        Updated work package dictionary or None if failed.
+    """
+    try:
+        with _get_client() as client:
+            payload: Dict[str, Any] = {"lockVersion": lock_version}
+
+            if status_id is not None:
+                payload["_links"] = payload.get("_links", {})
+                payload["_links"]["status"] = {"href": f"/api/v3/statuses/{status_id}"}
+
+            if assignee_id is not None:
+                payload["_links"] = payload.get("_links", {})
+                payload["_links"]["assignee"] = {"href": f"/api/v3/users/{assignee_id}"}
+
+            if description is not None:
+                payload["description"] = {"raw": description}
+
+            if subject is not None:
+                payload["subject"] = subject
+
+            response = client.patch(
+                f"/api/v3/work_packages/{work_package_id}",
+                json=payload,
+            )
+            response.raise_for_status()
+            wp = response.json()
+            logger.info(f"Updated work package {work_package_id}")
+            return wp
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to update work package {work_package_id}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error updating work package {work_package_id}: {e}")
+        return None
+
+
+def set_work_package_status(
+    work_package_id: int,
+    lock_version: int,
+    status_id: int,
+) -> Optional[Dict[str, Any]]:
+    """Set the status of a work package.
+
+    Args:
+        work_package_id: Work package ID
+        lock_version: Current lock version
+        status_id: New status ID
+
+    Returns:
+        Updated work package dictionary or None if failed.
+    """
+    return update_work_package(
+        work_package_id=work_package_id,
+        lock_version=lock_version,
+        status_id=status_id,
+    )
+
+
+def add_comment_to_work_package(
+    work_package_id: int,
+    comment: str,
+) -> bool:
+    """Add a comment to a work package.
+
+    Args:
+        work_package_id: Work package ID
+        comment: Comment text (markdown supported)
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    try:
+        with _get_client() as client:
+            payload = {"comment": {"raw": comment}}
+            response = client.post(
+                f"/api/v3/work_packages/{work_package_id}/activities",
+                json=payload,
+            )
+            response.raise_for_status()
+            logger.info(f"Added comment to work package {work_package_id}")
+            return True
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to add comment to work package {work_package_id}: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error adding comment to work package {work_package_id}: {e}")
+        return False
+
+
+def get_available_statuses(project_id: int) -> List[Dict[str, Any]]:
+    """Get available statuses for a project.
+
+    Args:
+        project_id: OpenProject project ID
+
+    Returns:
+        List of status dictionaries.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get(f"/api/v3/projects/{project_id}/available_statuses")
+            response.raise_for_status()
+            data = response.json()
+            return data.get("_embedded", {}).get("elements", [])
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get statuses for project {project_id}: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error getting statuses: {e}")
+        return []
+
+
+def get_user(user_id: int) -> Optional[Dict[str, Any]]:
+    """Get user information by ID.
+
+    Args:
+        user_id: OpenProject user ID
+
+    Returns:
+        User dictionary or None if not found.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get(f"/api/v3/users/{user_id}")
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get user {user_id}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error getting user {user_id}: {e}")
+        return None
+
+
+def get_current_user() -> Optional[Dict[str, Any]]:
+    """Get the current authenticated user.
+
+    Returns:
+        User dictionary or None if not found.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get("/api/v3/users/me")
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get current user: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error getting current user: {e}")
+        return None
+
+
+def get_work_package_types(project_id: int) -> List[Dict[str, Any]]:
+    """Get available work package types for a project.
+
+    Args:
+        project_id: OpenProject project ID
+
+    Returns:
+        List of type dictionaries.
+    """
+    try:
+        with _get_client() as client:
+            response = client.get(f"/api/v3/projects/{project_id}/types")
+            response.raise_for_status()
+            data = response.json()
+            return data.get("_embedded", {}).get("elements", [])
+    except httpx.HTTPError as e:
+        logger.error(f"Failed to get work package types for project {project_id}: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error getting work package types: {e}")
+        return []

--- a/src/auto_slopp/workers/__init__.py
+++ b/src/auto_slopp/workers/__init__.py
@@ -5,11 +5,13 @@ This package contains all worker implementations organized by functionality:
 """
 
 from auto_slopp.workers.github_issue_worker import GitHubIssueWorker
+from auto_slopp.workers.openproject_worker import OpenProjectWorker
 from auto_slopp.workers.pr_worker import PRWorker
 from auto_slopp.workers.stale_branch_cleanup_worker import StaleBranchCleanupWorker
 
 __all__ = [
     "GitHubIssueWorker",
+    "OpenProjectWorker",
     "PRWorker",
     "StaleBranchCleanupWorker",
 ]

--- a/src/auto_slopp/workers/openproject_worker.py
+++ b/src/auto_slopp/workers/openproject_worker.py
@@ -1,0 +1,866 @@
+"""OpenProject Worker for processing tasks from OpenProject.
+
+This worker:
+1. For each GitHub repository, finds matching OpenProject project by name
+2. Creates project if it doesn't exist (configurable)
+3. Searches for open tasks assigned to configured user
+4. Creates subtasks for the first open task
+5. Creates a new branch linked to the task
+6. Executes subtasks using the Ralph loop
+7. Commits changes and pushes branch
+8. Creates PR in GitHub
+9. Adds comment to OpenProject task and sets status to in progress
+"""
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from auto_slopp.utils.cli_executor import (
+    execute_with_instructions,
+    get_active_cli_command,
+)
+from auto_slopp.utils.git_operations import (
+    checkout_branch_resilient,
+    create_and_checkout_branch,
+    get_current_branch,
+    sanitize_branch_name,
+)
+from auto_slopp.utils.github_operations import (
+    create_pull_request,
+    get_pr_for_branch,
+)
+from auto_slopp.utils.openproject_operations import (
+    add_comment_to_work_package,
+    create_project,
+    create_subtask,
+    get_open_work_packages,
+    get_project_by_identifier,
+    get_project_by_name,
+    set_work_package_status,
+)
+from auto_slopp.utils.ralph import (
+    Plan,
+    PlanParser,
+    PlanWriter,
+    RalphLoop,
+    Step,
+)
+from auto_slopp.worker import Worker
+from settings.main import settings
+
+
+class OpenProjectWorker(Worker):
+    """Worker for processing OpenProject tasks.
+
+    This worker matches GitHub repositories to OpenProject projects by name,
+    processes open tasks assigned to a configured user, creates subtasks,
+    executes them, and creates PRs.
+    """
+
+    def __init__(
+        self,
+        timeout: int | None = None,
+        agent_args: Optional[List[str]] = None,
+        dry_run: bool = False,
+    ):
+        """Initialize the OpenProjectWorker.
+
+        Args:
+            timeout: Timeout for CLI execution in seconds (default: from settings.slop_timeout)
+            agent_args: Additional arguments to pass to the CLI tool
+            dry_run: If True, skip actual CLI execution and git operations
+        """
+        self.timeout = timeout if timeout is not None else settings.slop_timeout
+        self.agent_args = agent_args or []
+        self.dry_run = dry_run
+        self.logger = logging.getLogger("auto_slopp.workers.OpenProjectWorker")
+
+    def run(self, repo_path: Path) -> Dict[str, Any]:
+        """Execute the OpenProject task processing workflow for a single repository.
+
+        Args:
+            repo_path: Path to the repository directory
+
+        Returns:
+            Dictionary containing execution results and statistics
+        """
+        start_time = self._get_current_time()
+        self.logger.info(f"OpenProjectWorker starting with repo_path: {repo_path}")
+
+        if not self._is_configured():
+            return self._create_error_result(
+                start_time,
+                repo_path,
+                "OpenProject worker is not configured. Set openproject_url and openproject_api_token.",
+            )
+
+        if not repo_path.exists():
+            return self._create_error_result(
+                start_time,
+                repo_path,
+                f"Repository path does not exist: {repo_path}",
+            )
+
+        results = self._create_results_dict(start_time, repo_path)
+
+        if not self._checkout_main_branch(repo_dir=repo_path):
+            results["repositories_with_errors"] += 1
+            results["success"] = False
+            results["execution_time"] = self._get_elapsed_time(start_time)
+            self._log_completion_summary(results)
+            return results
+
+        project = self._get_or_create_project(repo_path.name)
+        if not project:
+            self.logger.warning(f"Could not find or create project for {repo_path.name}")
+            results["execution_time"] = self._get_elapsed_time(start_time)
+            self._log_completion_summary(results)
+            return results
+
+        project_id = project.get("id")
+        if not project_id:
+            results["execution_time"] = self._get_elapsed_time(start_time)
+            self._log_completion_summary(results)
+            return results
+
+        tasks = get_open_work_packages(
+            project_id=project_id,
+            assigned_to_user_id=settings.openproject_assigned_user_id,
+        )
+
+        if not tasks:
+            self.logger.info(f"No open tasks found in project {repo_path.name}")
+            results["execution_time"] = self._get_elapsed_time(start_time)
+            self._log_completion_summary(results)
+            return results
+
+        for task in tasks[:1]:
+            task_result = self._process_single_task(repo_path, task, project_id)
+            results["task_results"].append(task_result)
+
+            if task_result["success"]:
+                results["tasks_processed"] += 1
+                results["openagent_executions"] += task_result.get("openagent_executions", 0)
+                results["prs_created"] += task_result.get("prs_created", 0)
+                results["tasks_updated"] += task_result.get("tasks_updated", 0)
+            else:
+                self.logger.warning(
+                    f"Failed to process task #{task.get('id')}: {task_result.get('error', 'Unknown error')}"
+                )
+
+        results["execution_time"] = self._get_elapsed_time(start_time)
+        self._log_completion_summary(results)
+
+        return results
+
+    def _is_configured(self) -> bool:
+        """Check if OpenProject is properly configured.
+
+        Returns:
+            True if configured, False otherwise.
+        """
+        return bool(settings.openproject_url and settings.openproject_api_token)
+
+    def _get_or_create_project(self, repo_name: str) -> Optional[Dict[str, Any]]:
+        """Get or create OpenProject project matching repo name.
+
+        Args:
+            repo_name: Name of the repository (used as project identifier)
+
+        Returns:
+            Project dictionary or None if failed.
+        """
+        identifier = settings.openproject_project_prefix + repo_name.lower().replace("-", "_")
+
+        project = get_project_by_identifier(identifier)
+        if project:
+            return project
+
+        project = get_project_by_name(repo_name)
+        if project:
+            return project
+
+        if settings.openproject_create_projects:
+            self.logger.info(f"Creating OpenProject project for {repo_name}")
+            project = create_project(
+                name=repo_name,
+                identifier=identifier,
+                description=f"Auto-created project for repository {repo_name}",
+            )
+            return project
+
+        self.logger.info(f"Project not found for {repo_name} and auto-creation is disabled")
+        return None
+
+    def _create_results_dict(self, start_time: float, repo_path: Path) -> Dict[str, Any]:
+        """Create the initial results dictionary."""
+        return {
+            "worker_name": "OpenProjectWorker",
+            "execution_time": 0,
+            "timestamp": start_time,
+            "repo_path": str(repo_path),
+            "dry_run": self.dry_run,
+            "repositories_processed": 1,
+            "repositories_with_errors": 0,
+            "tasks_processed": 0,
+            "openagent_executions": 0,
+            "prs_created": 0,
+            "tasks_updated": 0,
+            "task_results": [],
+            "success": True,
+        }
+
+    def _checkout_main_branch(self, repo_dir: Path) -> bool:
+        """Checkout the main branch and pull latest changes.
+
+        Args:
+            repo_dir: Path to the repository directory
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.dry_run:
+            pull_success = checkout_branch_resilient(
+                repo_dir=repo_dir,
+                branch="main",
+                fetch_first=True,
+                timeout=60,
+            )
+            if not pull_success:
+                self.logger.warning(f"Failed to pull latest changes from {repo_dir.name}")
+                return False
+        return True
+
+    def _process_single_task(
+        self,
+        repo_dir: Path,
+        task: Dict[str, Any],
+        project_id: int,
+    ) -> Dict[str, Any]:
+        """Process a single task from OpenProject.
+
+        Args:
+            repo_dir: Path to the repository directory
+            task: The task dictionary from OpenProject API
+            project_id: OpenProject project ID
+
+        Returns:
+            Processing result for this task
+        """
+        self.logger.info(f"Processing OpenProject task for: {repo_dir.name}")
+
+        raw_task_id = task.get("id")
+        if raw_task_id is None:
+            return {
+                "repository": repo_dir.name,
+                "task_id": None,
+                "task_subject": task.get("subject", "Unknown"),
+                "success": False,
+                "error": "Task has no ID",
+                "openagent_executed": False,
+                "openagent_executions": 0,
+                "pr_created": False,
+                "prs_created": 0,
+                "task_updated": False,
+                "tasks_updated": 0,
+                "ralph_loops_executed": 0,
+                "ralph_steps_completed": 0,
+                "subtasks_created": 0,
+            }
+
+        task_id: int = raw_task_id
+        task_subject = task.get("subject", "Untitled Task")
+        task_description = ""
+        if task.get("description"):
+            task_description = task.get("description", {}).get("raw", "")
+
+        self.logger.info(f"Processing task #{task_id}: {task_subject}")
+
+        result = {
+            "repository": repo_dir.name,
+            "task_id": task_id,
+            "task_subject": task_subject,
+            "success": False,
+            "openagent_executed": False,
+            "openagent_executions": 0,
+            "pr_created": False,
+            "prs_created": 0,
+            "task_updated": False,
+            "tasks_updated": 0,
+            "error": None,
+            "ralph_loops_executed": 0,
+            "ralph_steps_completed": 0,
+            "subtasks_created": 0,
+        }
+
+        try:
+            branch_name = f"ai/op-{task_id}-{sanitize_branch_name(task_subject[:30].lower())}"
+
+            if self.dry_run:
+                self.logger.info(f"DRY RUN: Would create branch {branch_name} and execute with Ralph loop")
+                result["openagent_executed"] = True
+                result["success"] = True
+                return result
+
+            subtasks = self._create_subtasks_for_task(
+                task=task,
+                repo_dir=repo_dir,
+                project_id=project_id,
+            )
+            result["subtasks_created"] = len(subtasks)
+
+            branch_created = create_and_checkout_branch(repo_dir, branch_name, base_branch="main")
+            if not branch_created:
+                result["error"] = f"Failed to create branch {branch_name}"
+                return result
+
+            if settings.ralph_enabled and subtasks:
+                ralph_result = self._execute_with_ralph_loop(
+                    repo_dir=repo_dir,
+                    task=task,
+                    subtasks=subtasks,
+                    branch_name=branch_name,
+                    project_id=project_id,
+                )
+                result["ralph_loops_executed"] = ralph_result.get("loops_executed", 0)
+                result["ralph_steps_completed"] = ralph_result.get("steps_completed", 0)
+                result["openagent_executions"] = ralph_result.get("loops_executed", 0)
+
+                if not ralph_result.get("success", False):
+                    result["error"] = f"Ralph loop failed: {ralph_result.get('error', 'Unknown error')}"
+                    return result
+
+                result["openagent_executed"] = True
+            else:
+                instructions = self._build_instructions(
+                    task_subject=task_subject,
+                    task_description=task_description,
+                    branch_name=branch_name,
+                )
+
+                openagent_result = execute_with_instructions(
+                    instructions,
+                    repo_dir,
+                    self.agent_args,
+                    self.timeout,
+                    task_name="openproject_task",
+                )
+                result["openagent_executed"] = openagent_result["success"]
+                if openagent_result["success"]:
+                    result["openagent_executions"] = 1
+
+                if not openagent_result["success"]:
+                    cli_tool = get_active_cli_command()
+                    result["error"] = f"{cli_tool} execution failed: {openagent_result.get('error', 'Unknown error')}"
+                    return result
+
+            current_branch = get_current_branch(repo_dir)
+            if current_branch in ("main", "master"):
+                self.logger.info(f"No changes made for task #{task_id}, updating task with comment")
+
+                no_changes_comment = (
+                    "No changes required for this task. The task has been reviewed and no modifications are needed."
+                )
+                comment_success = add_comment_to_work_package(task_id, no_changes_comment)
+                result["task_commented"] = comment_success
+
+                result["task_updated"] = True
+                result["tasks_updated"] = 1
+
+                result["success"] = True
+                result["no_changes"] = True
+                return result
+
+            pr_body = f"OpenProject Task: #{task_id}\n\n{task_description}"
+
+            existing_pr = get_pr_for_branch(repo_dir, current_branch)
+            if existing_pr and existing_pr.get("state") == "OPEN":
+                result["pr_created"] = True
+                result["pr_url"] = existing_pr.get("url", "")
+                self.logger.info(f"PR already exists for branch '{current_branch}': {existing_pr.get('url', 'N/A')}")
+            else:
+                pr_result = create_pull_request(
+                    repo_dir,
+                    title=task_subject,
+                    body=pr_body,
+                    head=current_branch,
+                    base="main",
+                )
+
+                if pr_result:
+                    result["pr_created"] = True
+                    result["pr_url"] = pr_result.get("url", "")
+                    self.logger.info(f"Created PR for task #{task_id}: {pr_result.get('url', 'N/A')}")
+                else:
+                    existing_pr = get_pr_for_branch(repo_dir, current_branch)
+                    if existing_pr:
+                        result["pr_created"] = True
+                        result["pr_url"] = existing_pr.get("url", "")
+                        self.logger.info(
+                            f"Using existing PR for branch '{current_branch}': {existing_pr.get('url', 'N/A')}"
+                        )
+                    else:
+                        result["error"] = "Failed to create pull request"
+                        return result
+
+            lock_version = task.get("lockVersion", 1)
+            status_updated = set_work_package_status(
+                work_package_id=task_id,
+                lock_version=lock_version,
+                status_id=settings.openproject_in_progress_status_id,
+            )
+            result["task_status_updated"] = status_updated
+
+            pr_url = result.get("pr_url", "")
+            comment = f"Work completed by PR: {pr_url}\n\nThe task has been processed and is now in progress."
+            comment_success = add_comment_to_work_package(task_id, comment)
+            result["task_commented"] = comment_success
+
+            if status_updated or comment_success:
+                result["task_updated"] = True
+                result["tasks_updated"] = 1
+
+            result["success"] = True
+
+        except Exception as e:
+            self.logger.error(f"Error processing task #{task_id}: {str(e)}")
+            result["error"] = str(e)
+
+        return result
+
+    def _create_subtasks_for_task(
+        self,
+        task: Dict[str, Any],
+        repo_dir: Path,
+        project_id: int,
+    ) -> List[Dict[str, Any]]:
+        """Create subtasks for a parent task using CLI analysis.
+
+        Args:
+            task: Parent task dictionary
+            repo_dir: Repository directory path
+            project_id: OpenProject project ID
+
+        Returns:
+            List of created subtask dictionaries.
+        """
+        task_id: int = task.get("id", 0)
+        if task_id == 0:
+            self.logger.warning("Task has no ID, cannot create subtasks")
+            return []
+
+        task_subject = task.get("subject", "")
+        task_description = ""
+        if task.get("description"):
+            task_description = task.get("description", {}).get("raw", "")
+
+        subtask_descriptions = self._analyze_and_generate_subtasks(
+            task_subject=task_subject,
+            task_description=task_description,
+            repo_dir=repo_dir,
+        )
+
+        created_subtasks = []
+        for i, subtask_desc in enumerate(subtask_descriptions, 1):
+            subtask = create_subtask(
+                parent_work_package_id=task_id,
+                project_id=project_id,
+                subject=f"Subtask {i}: {subtask_desc[:50]}",
+                description=subtask_desc,
+            )
+            if subtask:
+                created_subtasks.append(subtask)
+                self.logger.info(f"Created subtask: {subtask.get('subject')}")
+
+        return created_subtasks
+
+    def _analyze_and_generate_subtasks(
+        self,
+        task_subject: str,
+        task_description: str,
+        repo_dir: Path,
+    ) -> List[str]:
+        """Analyze task and generate subtask descriptions using CLI.
+
+        Args:
+            task_subject: Task subject/title
+            task_description: Task description
+            repo_dir: Repository directory for context
+
+        Returns:
+            List of subtask descriptions.
+        """
+        default_subtasks = self._get_default_subtasks(task_subject)
+
+        analysis_instructions = f"""Analyze this OpenProject task and generate 3-7 specific subtasks:
+
+Task Subject: {task_subject}
+Task Description: {task_description}
+
+Generate subtasks that:
+1. Are specific and actionable
+2. Include mention of reusable components from the codebase
+3. Follow the standard development workflow
+4. Can be executed sequentially
+
+Format: Return ONLY a numbered list of subtask descriptions, one per line.
+Example:
+1. Analyze the existing implementation
+2. Identify reusable components
+3. Implement the core functionality
+4. Write tests
+5. Update documentation
+
+If you cannot analyze the task, return the default subtasks."""
+
+        try:
+            result = execute_with_instructions(
+                instructions=analysis_instructions,
+                work_dir=repo_dir,
+                agent_args=self.agent_args,
+                timeout=300,
+                task_name="openproject_subtask_generation",
+            )
+
+            if result.get("success") and result.get("stdout"):
+                subtasks = self._parse_subtasks_from_output(result["stdout"])
+                if subtasks:
+                    return subtasks
+        except Exception as e:
+            self.logger.warning(f"Failed to generate subtasks via CLI: {e}")
+
+        return default_subtasks
+
+    def _parse_subtasks_from_output(self, output: str) -> List[str]:
+        """Parse subtask descriptions from CLI output.
+
+        Args:
+            output: Raw CLI output
+
+        Returns:
+            List of subtask descriptions.
+        """
+        subtasks = []
+        for line in output.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+
+            if line[0].isdigit() and "." in line:
+                parts = line.split(".", 1)
+                if len(parts) > 1:
+                    subtask = parts[1].strip()
+                    if subtask:
+                        subtasks.append(subtask)
+
+            elif line.startswith("- "):
+                subtask = line[2:].strip()
+                if subtask:
+                    subtasks.append(subtask)
+
+        return subtasks if subtasks else []
+
+    def _get_default_subtasks(self, task_subject: str) -> List[str]:
+        """Get default subtask descriptions based on task subject.
+
+        Args:
+            task_subject: Task subject for context
+
+        Returns:
+            List of default subtask descriptions.
+        """
+        return [
+            "Understand the requirements and analyze the task description",
+            "Explore the codebase to understand the current implementation",
+            "Identify components that can be reused",
+            "Design a solution that is simple and focused",
+            "Write or update tests for the changes",
+            "Implement the solution",
+            "Run tests and lint checks, commit and push changes",
+        ]
+
+    def _execute_with_ralph_loop(
+        self,
+        repo_dir: Path,
+        task: Dict[str, Any],
+        subtasks: List[Dict[str, Any]],
+        branch_name: str,
+        project_id: int,
+    ) -> Dict[str, Any]:
+        """Execute task processing using Ralph loop with subtasks as steps.
+
+        Args:
+            repo_dir: Path to the repository directory
+            task: Parent task dictionary
+            subtasks: List of subtask dictionaries
+            branch_name: Branch name
+            project_id: OpenProject project ID
+
+        Returns:
+            Result dictionary from Ralph loop execution.
+        """
+        task_id = task.get("id")
+        plan_path = repo_dir / ".ralph" / f"op-task-{task_id}-plan.md"
+
+        plan = self._create_task_plan(
+            plan_path=plan_path,
+            task=task,
+            subtasks=subtasks,
+            branch_name=branch_name,
+        )
+
+        def step_executor(step: Step, current_plan: Plan) -> Dict[str, Any]:
+            return self._execute_step(
+                step=step,
+                plan=current_plan,
+                repo_dir=repo_dir,
+                task=task,
+                branch_name=branch_name,
+            )
+
+        ralph_loop = RalphLoop(
+            plan_path=plan_path,
+            max_loops=settings.ralph_max_loops,
+            step_executor=step_executor,
+        )
+        ralph_loop.plan = plan
+
+        return ralph_loop.run()
+
+    def _create_task_plan(
+        self,
+        plan_path: Path,
+        task: Dict[str, Any],
+        subtasks: List[Dict[str, Any]],
+        branch_name: str,
+    ) -> Plan:
+        """Create a plan file for the task based on subtasks.
+
+        Args:
+            plan_path: Path to save the plan file
+            task: Parent task dictionary
+            subtasks: List of subtask dictionaries
+            branch_name: Branch name
+
+        Returns:
+            Created Plan object.
+        """
+        task_subject = task.get("subject", "Untitled Task")
+        task_description = ""
+        if task.get("description"):
+            task_description = task.get("description", {}).get("raw", "")
+
+        description = f"Branch: {branch_name}\n\n{task_description}"
+
+        step_descriptions = []
+        for subtask in subtasks:
+            subject = subtask.get("subject", "")
+            desc = subtask.get("description", {}).get("raw", "")
+            step_descriptions.append(f"{subject}: {desc}" if desc else subject)
+
+        steps = [Step(number=i + 1, description=desc, is_closed=False) for i, desc in enumerate(step_descriptions)]
+
+        plan = Plan(
+            title=f"OpenProject Task Plan: {task_subject}",
+            description=description,
+            steps=steps,
+        )
+
+        PlanWriter.write_file(plan, plan_path)
+        self.logger.info(f"Created plan file: {plan_path}")
+
+        return plan
+
+    def _execute_step(
+        self,
+        step: Step,
+        plan: Plan,
+        repo_dir: Path,
+        task: Dict[str, Any],
+        branch_name: str,
+    ) -> Dict[str, Any]:
+        """Execute a single step from the plan.
+
+        Args:
+            step: Step to execute
+            plan: Current plan
+            repo_dir: Repository directory
+            task: Parent task dictionary
+            branch_name: Branch name
+
+        Returns:
+            Execution result dictionary.
+        """
+        step_instructions = self._build_step_instructions(
+            step=step,
+            plan=plan,
+            task=task,
+            branch_name=branch_name,
+        )
+
+        self.logger.info(f"Executing step {step.number}: {step.description}")
+
+        result = execute_with_instructions(
+            step_instructions,
+            repo_dir,
+            self.agent_args,
+            self.timeout,
+            task_name="openproject_task",
+        )
+
+        if result.get("success", False):
+            self.logger.info(f"Step {step.number} completed successfully")
+        else:
+            self.logger.warning(f"Step {step.number} failed: {result.get('error', 'Unknown error')}")
+
+        return result
+
+    def _build_step_instructions(
+        self,
+        step: Step,
+        plan: Plan,
+        task: Dict[str, Any],
+        branch_name: str,
+    ) -> str:
+        """Build instructions for a single step.
+
+        Args:
+            step: Step to build instructions for
+            plan: Current plan
+            task: Parent task dictionary
+            branch_name: Branch name
+
+        Returns:
+            Instructions string for the step.
+        """
+        task_subject = task.get("subject", "")
+        task_description = ""
+        if task.get("description"):
+            task_description = task.get("description", {}).get("raw", "")
+
+        body_text = f"\n{task_description}" if task_description else ""
+        progress_info = self._build_progress_info(plan)
+
+        return (
+            f"You are already on branch '{branch_name}'. "
+            f"Work on this branch, implement the changes, commit them, and push.\n"
+            f"Implement the following:\n"
+            f"Title: {task_subject}\n"
+            f"Description:{body_text}\n\n"
+            f"Current Progress:\n{progress_info}\n\n"
+            f"Your current task is Step {step.number}: {step.description}\n\n"
+            f"Focus only on completing this step. Once done, mark it as complete in your work. "
+            f"Keep your implementation simple. Only implement what is required. "
+            f"Check if there are components you can reuse. "
+            f"Ensure that 'make test' runs successful. Only push if ALL tests are successful. "
+            f"Check if you need to update the README.md."
+        )
+
+    def _build_progress_info(self, plan: Plan) -> str:
+        """Build progress information string.
+
+        Args:
+            plan: Current plan
+
+        Returns:
+            Progress information string.
+        """
+        lines = []
+        for step in plan.steps:
+            status = "✓" if step.is_closed else "○"
+            lines.append(f"{status} Step {step.number}: {step.description}")
+        return "\n".join(lines)
+
+    def _build_instructions(
+        self,
+        task_subject: str,
+        task_description: str,
+        branch_name: Optional[str] = None,
+    ) -> str:
+        """Build the instructions string from task subject and description.
+
+        Args:
+            task_subject: Task subject/title
+            task_description: Task description
+            branch_name: Name of the branch already created for this task
+
+        Returns:
+            Complete instructions string.
+        """
+        body_text = f"\n{task_description}" if task_description else ""
+
+        branch_instruction = ""
+        if branch_name:
+            branch_instruction = (
+                f"You are already on branch '{branch_name}'. "
+                f"Work on this branch, implement the changes, commit them, and push.\n"
+            )
+        else:
+            branch_instruction = "Create a new branch that starts with ai/ from base origin/main.\n"
+
+        plan_text = """
+Plan:
+1. Understand the requirements by analyzing the task title and description
+2. Explore the codebase to understand the current implementation
+3. Identify components that can be reused
+4. Design a solution that is simple and focused
+5. Write or update tests for the changes
+6. Implement the solution
+7. Run 'make lint' to ensure code quality
+8. Run 'make test' to verify all tests pass
+9. Commit the changes with a clear commit message
+10. Push the changes to the remote branch
+"""
+
+        return (
+            f"{branch_instruction}"
+            f"Implement the following:\n"
+            f"Title: {task_subject}\n"
+            f"Description:{body_text}\n"
+            f"{plan_text}\n"
+            f"Keep your implementation simple. Only implement what is required. "
+            f"Check if there are components you can reuse. "
+            f"Ensure that 'make test' runs successful. Only push if ALL tests are successful. "
+            f"Check if you need to update the README.md."
+        )
+
+    def _create_error_result(self, start_time: float, repo_path: Path, error_msg: str) -> Dict[str, Any]:
+        """Create an error result dictionary."""
+        return {
+            "worker_name": "OpenProjectWorker",
+            "execution_time": self._get_elapsed_time(start_time),
+            "timestamp": start_time,
+            "repo_path": str(repo_path),
+            "dry_run": self.dry_run,
+            "success": False,
+            "error": error_msg,
+            "repositories_processed": 0,
+            "repositories_with_errors": 1,
+            "tasks_processed": 0,
+            "openagent_executions": 0,
+            "prs_created": 0,
+            "tasks_updated": 0,
+            "task_results": [],
+        }
+
+    def _get_current_time(self) -> float:
+        """Get current time as float for consistent timing."""
+        return time.time()
+
+    def _get_elapsed_time(self, start_time: float) -> float:
+        """Get elapsed time from start time."""
+        return time.time() - start_time
+
+    def _log_completion_summary(self, results: Dict[str, Any]) -> None:
+        """Log completion summary."""
+        cli_tool = get_active_cli_command()
+        self.logger.info(
+            f"OpenProjectWorker completed. Processed: "
+            f"{results['tasks_processed']}, "
+            f"{cli_tool} executions: {results['openagent_executions']}, "
+            f"PRs created: {results['prs_created']}, "
+            f"Tasks updated: {results['tasks_updated']}, "
+            f"Errors: {results['repositories_with_errors']}"
+        )

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -219,6 +219,55 @@ class Settings(BaseSettings):
         description="Delay in seconds before reboot after auto-update (default: 5 minutes)",
     )
 
+    openproject_url: str = Field(
+        default="",
+        description="Base URL for OpenProject instance (e.g., https://openproject.example.com)",
+    )
+
+    openproject_api_token: str = Field(
+        default="",
+        description="API token for OpenProject authentication",
+    )
+
+    openproject_assigned_user_id: int = Field(
+        default=0,
+        ge=0,
+        description="User ID to filter tasks assigned to (auto-slopper user)",
+    )
+
+    openproject_default_status_id: int = Field(
+        default=1,
+        ge=1,
+        description="Default status ID for new tasks",
+    )
+
+    openproject_in_progress_status_id: int = Field(
+        default=2,
+        ge=1,
+        description="Status ID to set when task is in progress",
+    )
+
+    openproject_project_prefix: str = Field(
+        default="",
+        description="Optional prefix for project identifiers when creating new projects",
+    )
+
+    openproject_enabled: bool = Field(
+        default=False,
+        description="Enable OpenProject worker integration",
+    )
+
+    openproject_create_projects: bool = Field(
+        default=True,
+        description="Automatically create OpenProject projects if they don't exist",
+    )
+
+    openproject_task_type_id: int = Field(
+        default=1,
+        ge=1,
+        description="Default work package type ID for new tasks",
+    )
+
     model_config = {
         "env_prefix": "AUTO_SLOPP_",
         "env_file": ".env",

--- a/tests/test_openproject_operations.py
+++ b/tests/test_openproject_operations.py
@@ -1,0 +1,762 @@
+"""Tests for OpenProject operations utilities."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from auto_slopp.utils.openproject_operations import (
+    OpenProjectOperationError,
+    _get_client,
+    add_comment_to_work_package,
+    create_project,
+    create_subtask,
+    create_work_package,
+    get_available_statuses,
+    get_current_user,
+    get_open_work_packages,
+    get_project_by_identifier,
+    get_project_by_name,
+    get_projects,
+    get_user,
+    get_work_package,
+    get_work_package_types,
+    get_work_packages,
+    set_work_package_status,
+    update_work_package,
+)
+
+
+class TestGetClient:
+    """Tests for _get_client function."""
+
+    def test_get_client_configured_correctly(self):
+        """Test that client is configured with correct headers."""
+        with patch("auto_slopp.utils.openproject_operations.settings") as mock_settings:
+            mock_settings.openproject_url = "https://test.openproject.com/"
+            mock_settings.openproject_api_token = "test_token"
+
+            client = _get_client()
+
+            assert client is not None
+            assert "Bearer test_token" in client.headers.get("Authorization", "")
+            assert client.headers.get("Content-Type") == "application/json"
+            client.close()
+
+
+class TestGetProjects:
+    """Tests for get_projects function."""
+
+    def test_get_projects_success(self):
+        """Test successful retrieval of projects."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "_embedded": {
+                "elements": [
+                    {"id": 1, "name": "Project 1"},
+                    {"id": 2, "name": "Project 2"},
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(get=MagicMock(return_value=mock_response))
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            projects = get_projects()
+
+            assert len(projects) == 2
+            assert projects[0]["name"] == "Project 1"
+
+    def test_get_projects_empty(self):
+        """Test retrieval when no projects exist."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(get=MagicMock(return_value=mock_response))
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            projects = get_projects()
+
+            assert projects == []
+
+    def test_get_projects_http_error(self):
+        """Test handling of HTTP errors."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Connection failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            projects = get_projects()
+
+            assert projects == []
+
+
+class TestGetProjectByIdentifier:
+    """Tests for get_project_by_identifier function."""
+
+    def test_get_project_by_identifier_found(self):
+        """Test finding project by identifier."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": [{"id": 1, "identifier": "test_project"}]}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = get_project_by_identifier("test_project")
+
+            assert project is not None
+            assert project["identifier"] == "test_project"
+
+    def test_get_project_by_identifier_not_found(self):
+        """Test when project not found by identifier."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = get_project_by_identifier("nonexistent")
+
+            assert project is None
+
+
+class TestGetProjectByName:
+    """Tests for get_project_by_name function."""
+
+    def test_get_project_by_name_found(self):
+        """Test finding project by name."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": [{"id": 1, "name": "Test Project"}]}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = get_project_by_name("Test Project")
+
+            assert project is not None
+            assert project["name"] == "Test Project"
+
+    def test_get_project_by_name_not_found(self):
+        """Test when project not found by name."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = get_project_by_name("Nonexistent Project")
+
+            assert project is None
+
+
+class TestCreateProject:
+    """Tests for create_project function."""
+
+    def test_create_project_success(self):
+        """Test successful project creation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": 1,
+            "name": "New Project",
+            "identifier": "new_project",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = create_project(
+                name="New Project",
+                identifier="new_project",
+                description="Project description",
+            )
+
+            assert project is not None
+            assert project["name"] == "New Project"
+            mock_client_instance.post.assert_called_once()
+
+    def test_create_project_without_description(self):
+        """Test project creation without description."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": 1,
+            "name": "New Project",
+            "identifier": "new_project",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = create_project(name="New Project", identifier="new_project")
+
+            assert project is not None
+
+    def test_create_project_http_error(self):
+        """Test handling HTTP error during project creation."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.side_effect = httpx.HTTPError("Creation failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            project = create_project(name="New Project", identifier="new_project")
+
+            assert project is None
+
+
+class TestGetWorkPackages:
+    """Tests for get_work_packages function."""
+
+    def test_get_work_packages_success(self):
+        """Test successful retrieval of work packages."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "_embedded": {
+                "elements": [
+                    {"id": 1, "subject": "Task 1"},
+                    {"id": 2, "subject": "Task 2"},
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            work_packages = get_work_packages(project_id=1)
+
+            assert len(work_packages) == 2
+            assert work_packages[0]["subject"] == "Task 1"
+
+    def test_get_work_packages_with_filters(self):
+        """Test retrieval of work packages with filters."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"_embedded": {"elements": [{"id": 1, "subject": "Filtered Task"}]}}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            work_packages = get_work_packages(
+                project_id=1,
+                assigned_to_user_id=5,
+                status_id=7,
+            )
+
+            assert len(work_packages) == 1
+            call_args = mock_client_instance.get.call_args
+            assert "filters" in call_args.kwargs.get("params", {})
+
+
+class TestGetOpenWorkPackages:
+    """Tests for get_open_work_packages function."""
+
+    def test_get_open_work_packages_calls_get_work_packages(self):
+        """Test that get_open_work_packages calls get_work_packages correctly."""
+        with patch("auto_slopp.utils.openproject_operations.get_work_packages") as mock_get_wp:
+            mock_get_wp.return_value = [{"id": 1, "subject": "Open Task"}]
+
+            result = get_open_work_packages(project_id=1, assigned_to_user_id=5)
+
+            assert len(result) == 1
+            mock_get_wp.assert_called_once_with(
+                project_id=1,
+                assigned_to_user_id=5,
+                status_id=None,
+            )
+
+
+class TestGetWorkPackage:
+    """Tests for get_work_package function."""
+
+    def test_get_work_package_found(self):
+        """Test finding a work package by ID."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "subject": "Test Task"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = get_work_package(1)
+
+            assert wp is not None
+            assert wp["id"] == 1
+
+    def test_get_work_package_not_found(self):
+        """Test when work package not found."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Not found")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = get_work_package(999)
+
+            assert wp is None
+
+
+class TestCreateWorkPackage:
+    """Tests for create_work_package function."""
+
+    def test_create_work_package_success(self):
+        """Test successful work package creation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "subject": "New Task"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = create_work_package(
+                project_id=1,
+                subject="New Task",
+                description="Task description",
+            )
+
+            assert wp is not None
+            assert wp["subject"] == "New Task"
+
+    def test_create_work_package_with_all_options(self):
+        """Test work package creation with all options."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "subject": "New Task"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = create_work_package(
+                project_id=1,
+                subject="New Task",
+                description="Task description",
+                type_id=1,
+                parent_id=10,
+                assignee_id=5,
+            )
+
+            assert wp is not None
+            call_args = mock_client_instance.post.call_args
+            payload = call_args.kwargs.get("json", {})
+            assert "_links" in payload
+            assert "parent" in payload["_links"]
+            assert "assignee" in payload["_links"]
+
+
+class TestCreateSubtask:
+    """Tests for create_subtask function."""
+
+    def test_create_subtask_calls_create_work_package(self):
+        """Test that create_subtask calls create_work_package correctly."""
+        with patch("auto_slopp.utils.openproject_operations.create_work_package") as mock_create_wp:
+            mock_create_wp.return_value = {"id": 1, "subject": "Subtask"}
+
+            result = create_subtask(
+                parent_work_package_id=10,
+                project_id=1,
+                subject="Subtask",
+                description="Subtask description",
+            )
+
+            assert result is not None
+            mock_create_wp.assert_called_once_with(
+                project_id=1,
+                subject="Subtask",
+                description="Subtask description",
+                parent_id=10,
+            )
+
+
+class TestUpdateWorkPackage:
+    """Tests for update_work_package function."""
+
+    def test_update_work_package_status(self):
+        """Test updating work package status."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "subject": "Updated Task"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.patch.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = update_work_package(
+                work_package_id=1,
+                lock_version=1,
+                status_id=7,
+            )
+
+            assert wp is not None
+            call_args = mock_client_instance.patch.call_args
+            payload = call_args.kwargs.get("json", {})
+            assert payload["lockVersion"] == 1
+
+    def test_update_work_package_all_fields(self):
+        """Test updating all work package fields."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "subject": "Updated Task"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.patch.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            wp = update_work_package(
+                work_package_id=1,
+                lock_version=1,
+                status_id=7,
+                assignee_id=5,
+                description="New description",
+                subject="New subject",
+            )
+
+            assert wp is not None
+
+
+class TestSetWorkPackageStatus:
+    """Tests for set_work_package_status function."""
+
+    def test_set_work_package_status_calls_update(self):
+        """Test that set_work_package_status calls update_work_package."""
+        with patch("auto_slopp.utils.openproject_operations.update_work_package") as mock_update:
+            mock_update.return_value = {"id": 1, "subject": "Task"}
+
+            result = set_work_package_status(
+                work_package_id=1,
+                lock_version=1,
+                status_id=7,
+            )
+
+            assert result is not None
+            mock_update.assert_called_once_with(
+                work_package_id=1,
+                lock_version=1,
+                status_id=7,
+            )
+
+
+class TestAddCommentToWorkPackage:
+    """Tests for add_comment_to_work_package function."""
+
+    def test_add_comment_success(self):
+        """Test successfully adding a comment."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = add_comment_to_work_package(
+                work_package_id=1,
+                comment="This is a comment",
+            )
+
+            assert result is True
+
+    def test_add_comment_failure(self):
+        """Test handling failure when adding comment."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.post.side_effect = httpx.HTTPError("Failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = add_comment_to_work_package(
+                work_package_id=1,
+                comment="This is a comment",
+            )
+
+            assert result is False
+
+
+class TestGetAvailableStatuses:
+    """Tests for get_available_statuses function."""
+
+    def test_get_available_statuses_success(self):
+        """Test successful retrieval of statuses."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "_embedded": {
+                "elements": [
+                    {"id": 1, "name": "New"},
+                    {"id": 7, "name": "In Progress"},
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            statuses = get_available_statuses(project_id=1)
+
+            assert len(statuses) == 2
+            assert statuses[0]["name"] == "New"
+
+    def test_get_available_statuses_error(self):
+        """Test handling error when getting statuses."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            statuses = get_available_statuses(project_id=1)
+
+            assert statuses == []
+
+
+class TestGetUser:
+    """Tests for get_user function."""
+
+    def test_get_user_found(self):
+        """Test finding a user by ID."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "name": "Test User"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            user = get_user(1)
+
+            assert user is not None
+            assert user["name"] == "Test User"
+
+    def test_get_user_not_found(self):
+        """Test when user not found."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Not found")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            user = get_user(999)
+
+            assert user is None
+
+
+class TestGetCurrentUser:
+    """Tests for get_current_user function."""
+
+    def test_get_current_user_success(self):
+        """Test getting current user."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": 1, "name": "Current User"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            user = get_current_user()
+
+            assert user is not None
+            assert user["name"] == "Current User"
+
+    def test_get_current_user_error(self):
+        """Test handling error when getting current user."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            user = get_current_user()
+
+            assert user is None
+
+
+class TestGetWorkPackageTypes:
+    """Tests for get_work_package_types function."""
+
+    def test_get_work_package_types_success(self):
+        """Test successful retrieval of work package types."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "_embedded": {
+                "elements": [
+                    {"id": 1, "name": "Task"},
+                    {"id": 2, "name": "Feature"},
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            types = get_work_package_types(project_id=1)
+
+            assert len(types) == 2
+            assert types[0]["name"] == "Task"
+
+    def test_get_work_package_types_error(self):
+        """Test handling error when getting work package types."""
+        with (
+            patch("auto_slopp.utils.openproject_operations._get_client") as mock_client,
+            patch("auto_slopp.utils.openproject_operations.settings"),
+        ):
+            mock_client_instance = MagicMock()
+            mock_client_instance.get.side_effect = httpx.HTTPError("Failed")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            types = get_work_package_types(project_id=1)
+
+            assert types == []
+
+
+class TestOpenProjectOperationError:
+    """Tests for OpenProjectOperationError exception."""
+
+    def test_error_message(self):
+        """Test that error message is preserved."""
+        error = OpenProjectOperationError("Test error message")
+        assert str(error) == "Test error message"

--- a/tests/test_openproject_worker.py
+++ b/tests/test_openproject_worker.py
@@ -437,3 +437,484 @@ class TestOpenProjectWorker:
             mock_settings.openproject_api_token = ""
 
             assert worker._is_configured() is False
+
+    def test_process_single_task_no_id(self):
+        """Test _process_single_task with task that has no ID."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {"subject": "No ID Task"}
+
+            result = worker._process_single_task(repo_path, task, 1)
+
+            assert result["success"] is False
+            assert result["error"] == "Task has no ID"
+            assert result["task_id"] is None
+
+    def test_process_single_task_branch_creation_fails(self):
+        """Test _process_single_task when branch creation fails."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+            ):
+                mock_branch.return_value = False
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is False
+                assert "Failed to create branch" in result["error"]
+
+    def test_process_single_task_no_changes_made(self):
+        """Test _process_single_task when no changes are made (stays on main)."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.get_current_branch") as mock_get_branch,
+                patch("auto_slopp.workers.openproject_worker.add_comment_to_work_package") as mock_comment,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.execute_with_instructions") as mock_execute,
+            ):
+                mock_branch.return_value = True
+                mock_get_branch.return_value = "main"
+                mock_comment.return_value = True
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+                mock_settings.ralph_enabled = False
+                mock_execute.return_value = {"success": True}
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is True
+                assert result["no_changes"] is True
+                assert result["task_updated"] is True
+                assert result["task_commented"] is True
+                mock_comment.assert_called_once()
+
+    def test_process_single_task_creates_pr_successfully(self):
+        """Test _process_single_task creates PR successfully."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.get_current_branch") as mock_get_branch,
+                patch("auto_slopp.workers.openproject_worker.get_pr_for_branch") as mock_get_pr,
+                patch("auto_slopp.workers.openproject_worker.create_pull_request") as mock_create_pr,
+                patch("auto_slopp.workers.openproject_worker.set_work_package_status") as mock_status,
+                patch("auto_slopp.workers.openproject_worker.add_comment_to_work_package") as mock_comment,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.execute_with_instructions") as mock_execute,
+            ):
+                mock_branch.return_value = True
+                mock_get_branch.return_value = "ai/op-1-test-task"
+                mock_get_pr.return_value = None
+                mock_create_pr.return_value = {"url": "https://github.com/test/repo/pull/1"}
+                mock_status.return_value = True
+                mock_comment.return_value = True
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+                mock_settings.ralph_enabled = False
+                mock_settings.openproject_in_progress_status_id = 7
+                mock_execute.return_value = {"success": True}
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is True
+                assert result["pr_created"] is True
+                assert result["pr_url"] == "https://github.com/test/repo/pull/1"
+                assert result["task_status_updated"] is True
+                mock_create_pr.assert_called_once()
+                mock_status.assert_called_once()
+                mock_comment.assert_called_once()
+
+    def test_process_single_task_pr_already_exists(self):
+        """Test _process_single_task when PR already exists."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.get_current_branch") as mock_get_branch,
+                patch("auto_slopp.workers.openproject_worker.get_pr_for_branch") as mock_get_pr,
+                patch("auto_slopp.workers.openproject_worker.set_work_package_status") as mock_status,
+                patch("auto_slopp.workers.openproject_worker.add_comment_to_work_package") as mock_comment,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.execute_with_instructions") as mock_execute,
+            ):
+                mock_branch.return_value = True
+                mock_get_branch.return_value = "ai/op-1-test-task"
+                mock_get_pr.return_value = {
+                    "state": "OPEN",
+                    "url": "https://github.com/test/repo/pull/2",
+                }
+                mock_status.return_value = True
+                mock_comment.return_value = True
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+                mock_settings.ralph_enabled = False
+                mock_settings.openproject_in_progress_status_id = 7
+                mock_execute.return_value = {"success": True}
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is True
+                assert result["pr_created"] is True
+                assert result["pr_url"] == "https://github.com/test/repo/pull/2"
+
+    def test_process_single_task_pr_creation_fails(self):
+        """Test _process_single_task when PR creation fails."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.get_current_branch") as mock_get_branch,
+                patch("auto_slopp.workers.openproject_worker.get_pr_for_branch") as mock_get_pr,
+                patch("auto_slopp.workers.openproject_worker.create_pull_request") as mock_create_pr,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.execute_with_instructions") as mock_execute,
+            ):
+                mock_branch.return_value = True
+                mock_get_branch.return_value = "ai/op-1-test-task"
+                mock_get_pr.return_value = None
+                mock_create_pr.return_value = None
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+                mock_settings.ralph_enabled = False
+                mock_execute.return_value = {"success": True}
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is False
+                assert result["error"] == "Failed to create pull request"
+
+    def test_create_task_plan(self):
+        """Test _create_task_plan creates a proper plan."""
+        import tempfile
+        from pathlib import Path
+
+        from auto_slopp.utils.ralph import Plan, Step
+
+        worker = OpenProjectWorker(dry_run=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plan_path = Path(temp_dir) / ".ralph" / "test-plan.md"
+            plan_path.parent.mkdir(parents=True, exist_ok=True)
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+            }
+
+            subtasks = [
+                {"subject": "Subtask 1", "description": {"raw": "Desc 1"}},
+                {"subject": "Subtask 2", "description": {"raw": "Desc 2"}},
+            ]
+
+            plan = worker._create_task_plan(
+                plan_path=plan_path,
+                task=task,
+                subtasks=subtasks,
+                branch_name="ai/op-1-test",
+            )
+
+            assert plan is not None
+            assert plan.title == "OpenProject Task Plan: Test Task"
+            assert len(plan.steps) == 2
+            assert "ai/op-1-test" in plan.description
+            assert plan_path.exists()
+
+    def test_build_step_instructions(self):
+        """Test _build_step_instructions creates proper instructions."""
+        from auto_slopp.utils.ralph import Plan, Step
+
+        worker = OpenProjectWorker(dry_run=True)
+
+        plan = Plan(
+            title="Test Plan",
+            description="Test description",
+            steps=[
+                Step(number=1, description="First step", is_closed=True),
+                Step(number=2, description="Second step", is_closed=False),
+            ],
+        )
+
+        step = Step(number=2, description="Second step", is_closed=False)
+
+        task = {
+            "subject": "Test Task",
+            "description": {"raw": "Task description"},
+        }
+
+        instructions = worker._build_step_instructions(
+            step=step,
+            plan=plan,
+            task=task,
+            branch_name="ai/op-1-test",
+        )
+
+        assert "Test Task" in instructions
+        assert "Task description" in instructions
+        assert "ai/op-1-test" in instructions
+        assert "Step 2: Second step" in instructions
+        assert "✓" in instructions
+        assert "○" in instructions
+
+    def test_create_results_dict(self):
+        """Test _create_results_dict creates proper dictionary."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            result = worker._create_results_dict(1000.0, repo_path)
+
+            assert result["worker_name"] == "OpenProjectWorker"
+            assert result["repo_path"] == str(repo_path)
+            assert result["dry_run"] is True
+            assert result["repositories_processed"] == 1
+            assert result["repositories_with_errors"] == 0
+            assert result["tasks_processed"] == 0
+            assert result["success"] is True
+            assert result["task_results"] == []
+
+    def test_checkout_main_branch_failure(self):
+        """Test _checkout_main_branch when checkout fails."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            with patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout:
+                mock_checkout.return_value = False
+
+                result = worker._checkout_main_branch(repo_path)
+
+                assert result is False
+
+    def test_run_with_checkout_failure(self):
+        """Test run when checkout of main branch fails."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+            ):
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+                mock_checkout.return_value = False
+
+                worker = OpenProjectWorker(dry_run=False)
+                result = worker.run(repo_path)
+
+                assert result["success"] is False
+                assert result["repositories_with_errors"] == 1
+
+    def test_run_with_project_not_found_no_create(self):
+        """Test run when project not found and auto-creation is disabled."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+                patch("auto_slopp.workers.openproject_worker.get_project_by_name") as mock_get_name,
+                patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+            ):
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+                mock_settings.openproject_project_prefix = ""
+                mock_settings.openproject_create_projects = False
+                mock_get_id.return_value = None
+                mock_get_name.return_value = None
+                mock_checkout.return_value = True
+
+                worker = OpenProjectWorker(dry_run=False)
+                result = worker.run(repo_path)
+
+                assert result["success"] is True
+                assert result["tasks_processed"] == 0
+
+    def test_get_or_create_project_with_prefix(self):
+        """Test _get_or_create_project uses prefix correctly."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        mock_project = {"id": 1, "name": "test-repo", "identifier": "prefix_test_repo"}
+
+        with (
+            patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+        ):
+            mock_settings.openproject_project_prefix = "prefix_"
+            mock_settings.openproject_create_projects = True
+            mock_get_id.return_value = mock_project
+
+            result = worker._get_or_create_project("test-repo")
+
+            assert result == mock_project
+            mock_get_id.assert_called_once_with("prefix_test_repo")
+
+    def test_run_with_multiple_tasks_processes_only_first(self):
+        """Test that run processes only the first task when multiple exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            mock_project = {"id": 1, "name": "test_repo"}
+            mock_tasks = [
+                {
+                    "id": 1,
+                    "subject": "Task 1",
+                    "description": {"raw": "Desc 1"},
+                    "lockVersion": 1,
+                },
+                {
+                    "id": 2,
+                    "subject": "Task 2",
+                    "description": {"raw": "Desc 2"},
+                    "lockVersion": 1,
+                },
+            ]
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_project,
+                patch("auto_slopp.workers.openproject_worker.get_open_work_packages") as mock_get_tasks,
+                patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+            ):
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+                mock_settings.openproject_assigned_user_id = 1
+                mock_settings.openproject_project_prefix = ""
+                mock_settings.openproject_create_projects = True
+                mock_get_project.return_value = mock_project
+                mock_get_tasks.return_value = mock_tasks
+                mock_checkout.return_value = True
+
+                worker = OpenProjectWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is True
+                assert result["tasks_processed"] == 1
+                assert result["task_results"][0]["task_id"] == 1
+
+    def test_process_single_task_with_exception(self):
+        """Test _process_single_task handles exceptions gracefully."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,):
+                mock_branch.side_effect = Exception("Unexpected error")
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is False
+                assert "Unexpected error" in result["error"]
+
+    def test_process_single_task_execution_fails(self):
+        """Test _process_single_task when CLI execution fails."""
+        worker = OpenProjectWorker(dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            task = {
+                "id": 1,
+                "subject": "Test Task",
+                "description": {"raw": "Test description"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.create_and_checkout_branch") as mock_branch,
+                patch("auto_slopp.workers.openproject_worker.create_subtask") as mock_subtask,
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.execute_with_instructions") as mock_execute,
+                patch("auto_slopp.workers.openproject_worker.get_active_cli_command") as mock_cli,
+            ):
+                mock_branch.return_value = True
+                mock_subtask.return_value = {"id": 100, "subject": "Subtask 1"}
+                mock_settings.ralph_enabled = False
+                mock_execute.return_value = {"success": False, "error": "CLI failed"}
+                mock_cli.return_value = "test-cli"
+
+                result = worker._process_single_task(repo_path, task, 1)
+
+                assert result["success"] is False
+                assert "CLI failed" in result["error"]

--- a/tests/test_openproject_worker.py
+++ b/tests/test_openproject_worker.py
@@ -1,0 +1,439 @@
+"""Tests for OpenProjectWorker."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from auto_slopp.workers.openproject_worker import OpenProjectWorker
+
+
+class TestOpenProjectWorker:
+    """Tests for OpenProjectWorker."""
+
+    def test_initialization_success(self):
+        """Test successful worker initialization."""
+        worker = OpenProjectWorker(
+            timeout=7200,
+            agent_args=["--verbose"],
+            dry_run=True,
+        )
+
+        assert worker.timeout == 7200
+        assert worker.agent_args == ["--verbose"]
+        assert worker.dry_run is True
+
+    def test_run_with_not_configured(self):
+        """Test run when OpenProject is not configured."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            with patch("auto_slopp.workers.openproject_worker.settings") as mock_settings:
+                mock_settings.openproject_url = ""
+                mock_settings.openproject_api_token = ""
+
+                worker = OpenProjectWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is False
+                assert "not configured" in result["error"]
+
+    def test_run_with_no_tasks(self):
+        """Test run with no open tasks."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            mock_project = {"id": 1, "name": "test_repo"}
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_project,
+                patch("auto_slopp.workers.openproject_worker.get_open_work_packages") as mock_get_tasks,
+                patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+            ):
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+                mock_settings.openproject_assigned_user_id = 1
+                mock_settings.openproject_project_prefix = ""
+                mock_settings.openproject_create_projects = True
+                mock_get_project.return_value = mock_project
+                mock_get_tasks.return_value = []
+                mock_checkout.return_value = True
+
+                worker = OpenProjectWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is True
+                assert result["repositories_processed"] == 1
+                assert result["repositories_with_errors"] == 0
+                assert result["tasks_processed"] == 0
+
+    def test_run_with_tasks_dry_run(self):
+        """Test run with open tasks in dry run mode."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            mock_project = {"id": 1, "name": "test_repo"}
+            mock_task = {
+                "id": 42,
+                "subject": "Test Task",
+                "description": {"raw": "This is a test task"},
+                "lockVersion": 1,
+            }
+
+            with (
+                patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_project,
+                patch("auto_slopp.workers.openproject_worker.get_open_work_packages") as mock_get_tasks,
+                patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+            ):
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+                mock_settings.openproject_assigned_user_id = 1
+                mock_settings.openproject_project_prefix = ""
+                mock_settings.openproject_create_projects = True
+                mock_get_project.return_value = mock_project
+                mock_get_tasks.return_value = [mock_task]
+                mock_checkout.return_value = True
+
+                worker = OpenProjectWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is True
+                assert result["repositories_processed"] == 1
+                assert result["tasks_processed"] == 1
+                assert result["task_results"][0]["task_id"] == 42
+                assert result["task_results"][0]["task_subject"] == "Test Task"
+
+    def test_run_with_nonexistent_repo(self):
+        """Test run with nonexistent repository path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "nonexistent_repo"
+
+            with patch("auto_slopp.workers.openproject_worker.settings") as mock_settings:
+                mock_settings.openproject_url = "https://test.openproject.com"
+                mock_settings.openproject_api_token = "test_token"
+
+                worker = OpenProjectWorker(dry_run=True)
+                result = worker.run(repo_path)
+
+                assert result["success"] is False
+                assert "error" in result
+
+    def test_build_instructions(self):
+        """Test instruction building."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Fix bug", "This is a bug")
+        assert "Fix bug" in instructions
+        assert "This is a bug" in instructions
+        assert "ai/" in instructions
+
+    def test_build_instructions_with_branch_name(self):
+        """Test instruction building with branch name provided."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        instructions = worker._build_instructions(
+            "Fix bug",
+            "This is a bug",
+            branch_name="ai/op-1-fix-bug",
+        )
+        assert "Fix bug" in instructions
+        assert "This is a bug" in instructions
+        assert "already on branch 'ai/op-1-fix-bug'" in instructions
+        assert "Create a new branch" not in instructions
+
+    def test_build_instructions_empty_description(self):
+        """Test instruction building with empty description."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Test task", "")
+        assert "Test task" in instructions
+        assert "ai/" in instructions
+
+    def test_build_instructions_includes_plan(self):
+        """Test that instructions include a structured plan."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        instructions = worker._build_instructions("Test task", "Test description")
+        assert "Plan:" in instructions
+        assert "1." in instructions
+        assert "2." in instructions
+        assert "Understand the requirements" in instructions
+        assert "Explore the codebase" in instructions
+        assert "make lint" in instructions
+        assert "make test" in instructions
+        assert "Commit the changes" in instructions
+        assert "Push the changes" in instructions
+
+    def test_create_error_result(self):
+        """Test error result creation."""
+        worker = OpenProjectWorker(dry_run=True)
+        start_time = 1000.0
+
+        result = worker._create_error_result(
+            start_time,
+            Path("/test/repo"),
+            "Test error",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "Test error"
+        assert result["worker_name"] == "OpenProjectWorker"
+
+    def test_get_default_subtasks(self):
+        """Test default subtask generation."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        subtasks = worker._get_default_subtasks("Test Task")
+
+        assert len(subtasks) > 0
+        assert any("requirements" in s.lower() for s in subtasks)
+        assert any("codebase" in s.lower() for s in subtasks)
+
+    def test_parse_subtasks_from_output_numbered(self):
+        """Test parsing numbered subtasks from output."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        output = """1. First subtask
+2. Second subtask
+3. Third subtask"""
+
+        subtasks = worker._parse_subtasks_from_output(output)
+
+        assert len(subtasks) == 3
+        assert subtasks[0] == "First subtask"
+        assert subtasks[1] == "Second subtask"
+        assert subtasks[2] == "Third subtask"
+
+    def test_parse_subtasks_from_output_bullets(self):
+        """Test parsing bullet subtasks from output."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        output = """- First subtask
+- Second subtask
+- Third subtask"""
+
+        subtasks = worker._parse_subtasks_from_output(output)
+
+        assert len(subtasks) == 3
+        assert subtasks[0] == "First subtask"
+        assert subtasks[1] == "Second subtask"
+        assert subtasks[2] == "Third subtask"
+
+    def test_parse_subtasks_from_output_mixed(self):
+        """Test parsing mixed format subtasks from output."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        output = """1. First subtask
+- Second subtask (as bullet)
+2. Third subtask"""
+
+        subtasks = worker._parse_subtasks_from_output(output)
+
+        assert len(subtasks) >= 2
+
+    def test_parse_subtasks_from_output_empty(self):
+        """Test parsing empty output."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        subtasks = worker._parse_subtasks_from_output("")
+
+        assert subtasks == []
+
+    def test_build_progress_info(self):
+        """Test progress info building."""
+        from auto_slopp.utils.ralph import Plan, Step
+
+        worker = OpenProjectWorker(dry_run=True)
+
+        plan = Plan(
+            title="Test Plan",
+            description="Test description",
+            steps=[
+                Step(number=1, description="First step", is_closed=True),
+                Step(number=2, description="Second step", is_closed=False),
+                Step(number=3, description="Third step", is_closed=False),
+            ],
+        )
+
+        progress = worker._build_progress_info(plan)
+
+        assert "✓" in progress
+        assert "○" in progress
+        assert "Step 1" in progress
+        assert "Step 2" in progress
+        assert "Step 3" in progress
+
+    def test_branch_name_sanitization(self):
+        """Test that branch names are properly sanitized from task subjects."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir) / "repos" / "test_repo"
+            repo_path.mkdir(parents=True)
+
+            mock_project = {"id": 1, "name": "test_repo"}
+
+            test_cases = [
+                {"subject": "Fix bug", "expected_prefix": "ai/op-1-fix-bug"},
+                {
+                    "subject": "Feature: Add new functionality",
+                    "expected_prefix": "ai/op-2-feature-add-new-functio",
+                },
+                {
+                    "subject": "Task with:colon",
+                    "expected_prefix": "ai/op-3-task-with-colon",
+                },
+            ]
+
+            for i, test_case in enumerate(test_cases, start=1):
+                mock_task = {
+                    "id": i,
+                    "subject": test_case["subject"],
+                    "description": {"raw": "Test description"},
+                    "lockVersion": 1,
+                }
+
+                with (
+                    patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+                    patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_project,
+                    patch("auto_slopp.workers.openproject_worker.get_open_work_packages") as mock_get_tasks,
+                    patch("auto_slopp.workers.openproject_worker.checkout_branch_resilient") as mock_checkout,
+                ):
+                    mock_settings.openproject_url = "https://test.openproject.com"
+                    mock_settings.openproject_api_token = "test_token"
+                    mock_settings.openproject_assigned_user_id = 1
+                    mock_settings.openproject_project_prefix = ""
+                    mock_settings.openproject_create_projects = True
+                    mock_get_project.return_value = mock_project
+                    mock_get_tasks.return_value = [mock_task]
+                    mock_checkout.return_value = True
+
+                    result = worker.run(repo_path)
+
+                    assert result["success"] is True
+                    assert result["tasks_processed"] == 1
+
+                    from auto_slopp.utils.git_operations import sanitize_branch_name
+
+                    sanitized_subject = sanitize_branch_name(test_case["subject"][:30].lower())
+                    expected_branch = f"ai/op-{i}-{sanitized_subject}"
+
+                    assert result["task_results"][0]["task_subject"] == test_case["subject"]
+
+    def test_get_or_create_project_existing_by_identifier(self):
+        """Test getting existing project by identifier."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        mock_project = {"id": 1, "name": "test-repo", "identifier": "test_repo"}
+
+        with (
+            patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+        ):
+            mock_settings.openproject_project_prefix = ""
+            mock_settings.openproject_create_projects = True
+            mock_get_id.return_value = mock_project
+
+            result = worker._get_or_create_project("test-repo")
+
+            assert result == mock_project
+            mock_get_id.assert_called_once_with("test_repo")
+
+    def test_get_or_create_project_existing_by_name(self):
+        """Test getting existing project by name when identifier not found."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        mock_project = {"id": 1, "name": "test-repo", "identifier": "test_repo"}
+
+        with (
+            patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_name") as mock_get_name,
+        ):
+            mock_settings.openproject_project_prefix = ""
+            mock_settings.openproject_create_projects = True
+            mock_get_id.return_value = None
+            mock_get_name.return_value = mock_project
+
+            result = worker._get_or_create_project("test-repo")
+
+            assert result == mock_project
+            mock_get_id.assert_called_once()
+            mock_get_name.assert_called_once_with("test-repo")
+
+    def test_get_or_create_project_create_new(self):
+        """Test creating new project when it doesn't exist."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        mock_project = {"id": 1, "name": "test-repo", "identifier": "test_repo"}
+
+        with (
+            patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_name") as mock_get_name,
+            patch("auto_slopp.workers.openproject_worker.create_project") as mock_create,
+        ):
+            mock_settings.openproject_project_prefix = ""
+            mock_settings.openproject_create_projects = True
+            mock_get_id.return_value = None
+            mock_get_name.return_value = None
+            mock_create.return_value = mock_project
+
+            result = worker._get_or_create_project("test-repo")
+
+            assert result == mock_project
+            mock_create.assert_called_once()
+
+    def test_get_or_create_project_no_create(self):
+        """Test not creating project when auto-creation is disabled."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with (
+            patch("auto_slopp.workers.openproject_worker.settings") as mock_settings,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_identifier") as mock_get_id,
+            patch("auto_slopp.workers.openproject_worker.get_project_by_name") as mock_get_name,
+        ):
+            mock_settings.openproject_project_prefix = ""
+            mock_settings.openproject_create_projects = False
+            mock_get_id.return_value = None
+            mock_get_name.return_value = None
+
+            result = worker._get_or_create_project("test-repo")
+
+            assert result is None
+
+    def test_is_configured_true(self):
+        """Test is_configured returns True when properly configured."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with patch("auto_slopp.workers.openproject_worker.settings") as mock_settings:
+            mock_settings.openproject_url = "https://test.openproject.com"
+            mock_settings.openproject_api_token = "test_token"
+
+            assert worker._is_configured() is True
+
+    def test_is_configured_false_no_url(self):
+        """Test is_configured returns False when URL is missing."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with patch("auto_slopp.workers.openproject_worker.settings") as mock_settings:
+            mock_settings.openproject_url = ""
+            mock_settings.openproject_api_token = "test_token"
+
+            assert worker._is_configured() is False
+
+    def test_is_configured_false_no_token(self):
+        """Test is_configured returns False when token is missing."""
+        worker = OpenProjectWorker(dry_run=True)
+
+        with patch("auto_slopp.workers.openproject_worker.settings") as mock_settings:
+            mock_settings.openproject_url = "https://test.openproject.com"
+            mock_settings.openproject_api_token = ""
+
+            assert worker._is_configured() is False


### PR DESCRIPTION
Closes #253

Create an OpenprojectWorker similar to the Githubissueworker.

The OpenProjectWorker should do the following for each github repository. The name of the directory of the githubs repository and the project in openproject is the same. If the project in openproject does not exist it needs to be created:
- Search for Tasks that are assigned to the auto-slopper user (configurable) and are open
- Create subtasks for the first open task. These tasks should have a good description of what has to be done to fulfill the parent task. Ensure that all components that can be re-used are mentioned.
- Create a new branch (similar to the githubissueworker. Ensure the branchname is connected to the task in openproject) and complete all the subtasks.
- Commit the changes and Push the branch
- create a PR in github.
- Give a brief description of what has been done as a  comment in the openproject task and set the task to in progress.

Ensure that all required settings are configurable