### PR TITLE
Issue #9: commit changes after CLI tool fixes in PRWorker

### DIFF
--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List
 from auto_slopp.utils.cli_executor import get_active_cli_command, run_cli_executor
 from auto_slopp.utils.git_operations import (
     checkout_branch_resilient,
+    commit_and_push_changes,
+    has_changes,
     merge_main_into_branch,
     push_branch,
 )
@@ -145,6 +147,13 @@ class PRWorker(Worker):
                     self.logger.info(f"Merge failed for {branch} in {repo_dir.name}, using {cli_tool} to fix")
                     fix_result = self._fix_merge_with_cli(repo_dir)
                     if fix_result["success"]:
+                        if has_changes(repo_dir):
+                            self.logger.info(f"Committing changes after CLI merge fix for {branch} in {repo_dir.name}")
+                            commit_and_push_changes(
+                                repo_dir,
+                                f"fix: commit changes after CLI merge fix for {branch}",
+                                push_if_remote=False,
+                            )
                         if not self._update_branch_with_main(repo_dir, branch):
                             result["error"] = f"Failed to update branch {branch} with main after fix attempt"
                             continue
@@ -169,6 +178,13 @@ class PRWorker(Worker):
                     self.logger.info(f"Tests failed for {branch} in {repo_dir.name}, using {cli_tool} to fix")
                     fix_result = self._fix_tests_with_cli(repo_dir)
                     if fix_result["success"]:
+                        if has_changes(repo_dir):
+                            self.logger.info(f"Committing changes after CLI fix for {branch} in {repo_dir.name}")
+                            commit_and_push_changes(
+                                repo_dir,
+                                f"fix: commit changes after CLI test fix for {branch}",
+                                push_if_remote=False,
+                            )
                         result["tests_fixed"] = True
                         verify_result = self._run_tests(repo_dir)
                         tests_successful = verify_result["success"]

--- a/tests/test_pr_worker.py
+++ b/tests/test_pr_worker.py
@@ -49,11 +49,102 @@ class TestPRWorker:
             ),
             patch.object(worker, "_fix_tests_with_cli", return_value={"success": True}),
             patch.object(worker, "_push_branch", return_value=True) as mock_push_branch,
+            patch("auto_slopp.workers.pr_worker.has_changes", return_value=True),
+            patch("auto_slopp.workers.pr_worker.commit_and_push_changes", return_value=(True, None)),
         ):
             result = worker._process_repository(repo_dir)
 
         assert result["success"] is True
         assert mock_push_branch.call_count == 1
+
+    def test_commits_changes_after_cli_test_fix(self):
+        """Test that PRWorker commits changes after CLI tool fixes tests."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        with (
+            patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
+            patch.object(worker, "_checkout_branch", return_value=True),
+            patch.object(worker, "_update_branch_with_main", return_value=True),
+            patch.object(
+                worker,
+                "_run_tests",
+                side_effect=[
+                    {"success": False, "output": "", "error": "failed"},
+                    {"success": True, "output": "", "error": None},
+                ],
+            ),
+            patch.object(worker, "_fix_tests_with_cli", return_value={"success": True}),
+            patch.object(worker, "_push_branch", return_value=True),
+            patch("auto_slopp.workers.pr_worker.has_changes", return_value=True) as mock_has_changes,
+            patch("auto_slopp.workers.pr_worker.commit_and_push_changes", return_value=(True, None)) as mock_commit,
+        ):
+            worker._process_repository(repo_dir)
+
+        mock_has_changes.assert_called_once_with(repo_dir)
+        mock_commit.assert_called_once_with(
+            repo_dir,
+            "fix: commit changes after CLI test fix for feature",
+            push_if_remote=False,
+        )
+
+    def test_no_commit_when_no_changes_after_cli_test_fix(self):
+        """Test that PRWorker skips commit when CLI tool made no changes."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        with (
+            patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
+            patch.object(worker, "_checkout_branch", return_value=True),
+            patch.object(worker, "_update_branch_with_main", return_value=True),
+            patch.object(
+                worker,
+                "_run_tests",
+                side_effect=[
+                    {"success": False, "output": "", "error": "failed"},
+                    {"success": True, "output": "", "error": None},
+                ],
+            ),
+            patch.object(worker, "_fix_tests_with_cli", return_value={"success": True}),
+            patch.object(worker, "_push_branch", return_value=True),
+            patch("auto_slopp.workers.pr_worker.has_changes", return_value=False),
+            patch("auto_slopp.workers.pr_worker.commit_and_push_changes", return_value=(True, None)) as mock_commit,
+        ):
+            worker._process_repository(repo_dir)
+
+        mock_commit.assert_not_called()
+
+    def test_commits_changes_after_cli_merge_fix(self):
+        """Test that PRWorker commits changes after CLI tool fixes merge conflicts."""
+        worker = PRWorker()
+        repo_dir = Path("/tmp/repo")
+
+        with (
+            patch.object(worker, "_get_open_pr_branches", return_value=["feature"]),
+            patch.object(worker, "_checkout_branch", return_value=True),
+            patch.object(
+                worker,
+                "_update_branch_with_main",
+                side_effect=[False, True],
+            ),
+            patch.object(
+                worker,
+                "_run_tests",
+                return_value={"success": True, "output": "", "error": None},
+            ),
+            patch.object(worker, "_fix_merge_with_cli", return_value={"success": True}),
+            patch.object(worker, "_push_branch", return_value=True),
+            patch("auto_slopp.workers.pr_worker.has_changes", return_value=True) as mock_has_changes,
+            patch("auto_slopp.workers.pr_worker.commit_and_push_changes", return_value=(True, None)) as mock_commit,
+        ):
+            worker._process_repository(repo_dir)
+
+        mock_has_changes.assert_called_once_with(repo_dir)
+        mock_commit.assert_called_once_with(
+            repo_dir,
+            "fix: commit changes after CLI merge fix for feature",
+            push_if_remote=False,
+        )
 
     def test_filters_prs_by_allowed_creator(self):
         """Test that PRWorker only processes PRs from allowed creator."""


### PR DESCRIPTION
PRWorker was not committing changes made by the CLI tool after fixing tests or merge conflicts, leading to uncommitted changes on branches.

Added has_changes() check and commit_and_push_changes() calls after both _fix_tests_with_cli() and _fix_merge_with_cli() succeed. Added tests to verify commit behavior.