### PR TITLE
#339: When using the vikunjaworker the tasks are not getting workedn on in teh correct repository. It seems kind of random which task end up worked on in which repository

### DIFF
--- a/src/auto_slopp/utils/vikunja_operations.py
+++ b/src/auto_slopp/utils/vikunja_operations.py
@@ -156,6 +156,11 @@ def find_or_create_project(project_name: str, project_identifier: Optional[str] 
     Returns:
         Dictionary containing project information or None if failed.
     """
+    if project_identifier:
+        project = find_project(project_identifier)
+        if project is not None:
+            return project
+
     project = find_project(project_name)
     if project is not None:
         return project

--- a/src/auto_slopp/workers/vikunja_task_source.py
+++ b/src/auto_slopp/workers/vikunja_task_source.py
@@ -37,8 +37,19 @@ class VikunjaTaskSource(TaskSource):
             List of normalized Task objects ready for processing
         """
         project_name = repo_path.name
+        # Create a unique project identifier based on the full path to avoid conflicts
+        # between repositories with the same name in different locations
+        import hashlib
 
-        project = find_or_create_project(project_name)
+        path_hash = hashlib.md5(str(repo_path.absolute()).encode(), usedforsecurity=False).hexdigest()[:6]
+        project_identifier = f"{project_name[:3]}-{path_hash}".lower()
+        # Ensure identifier is exactly 10 characters as per Vikunja requirements
+        if len(project_identifier) > 10:
+            project_identifier = project_identifier[:10]
+        else:
+            project_identifier = project_identifier.ljust(10, "-")
+
+        project = find_or_create_project(project_name, project_identifier)
         if not project:
             logger.error(f"Failed to find or create Vikunja project: {project_name}")
             return []

--- a/tests/test_task_source.py
+++ b/tests/test_task_source.py
@@ -314,7 +314,13 @@ class TestVikunjaTaskSource:
         source = VikunjaTaskSource()
         tasks = source.get_tasks(Path("/tmp"))
         assert len(tasks) == 0
-        mock_find_project.assert_called_once_with("tmp")
+        # Check that find_or_create_project was called with correct arguments
+        # First argument is project name, second is generated identifier
+        mock_find_project.assert_called_once()
+        args, kwargs = mock_find_project.call_args
+        assert args[0] == "tmp"  # project name
+        assert len(args[1]) == 10  # identifier should be 10 chars
+        assert args[1].startswith("tmp-")  # identifier should start with tmp-
 
     @patch("auto_slopp.workers.vikunja_task_source.find_or_create_project")
     @patch("auto_slopp.workers.vikunja_task_source.get_open_tasks_by_project")

--- a/tests/test_vikunja_operations.py
+++ b/tests/test_vikunja_operations.py
@@ -731,6 +731,90 @@ class TestFindOrCreateProject:
 
             assert result is None
 
+    def test_find_by_identifier_first(self):
+        """Test that find_or_create_project searches by identifier before project name."""
+        with patch("auto_slopp.utils.vikunja_operations.find_project") as mock_find:
+            mock_find.return_value = {
+                "id": 1,
+                "title": "my-repo",
+                "identifier": "rep-abc123",
+            }
+
+            result = find_or_create_project("my-repo", "rep-abc123")
+
+            assert result is not None
+            assert result["id"] == 1
+            assert result["identifier"] == "rep-abc123"
+            mock_find.assert_called_once_with("rep-abc123")
+
+    def test_fallback_to_project_name_when_identifier_not_found(self):
+        """Test that find_or_create_project falls back to project name when identifier not found."""
+        with (
+            patch("auto_slopp.utils.vikunja_operations.find_project") as mock_find,
+            patch("auto_slopp.utils.vikunja_operations.create_project") as mock_create,
+        ):
+            mock_find.side_effect = [
+                None,
+                {"id": 2, "title": "my-repo", "identifier": "my-repo"},
+            ]
+            mock_create.return_value = None
+
+            result = find_or_create_project("my-repo", "rep-abc123")
+
+            assert result is not None
+            assert result["id"] == 2
+            assert mock_find.call_count == 2
+            assert mock_find.call_args_list[0][0][0] == "rep-abc123"
+            assert mock_find.call_args_list[1][0][0] == "my-repo"
+            mock_create.assert_not_called()
+
+    def test_create_project_when_both_identifier_and_name_not_found(self):
+        """Test that find_or_create_project creates a new project when both identifier and name not found."""
+        with (
+            patch("auto_slopp.utils.vikunja_operations.find_project") as mock_find,
+            patch("auto_slopp.utils.vikunja_operations.create_project") as mock_create,
+        ):
+            mock_find.return_value = None
+            mock_create.return_value = {
+                "id": 3,
+                "title": "my-repo",
+                "identifier": "rep-abc123",
+            }
+
+            result = find_or_create_project("my-repo", "rep-abc123")
+
+            assert result is not None
+            assert result["id"] == 3
+            assert result["identifier"] == "rep-abc123"
+            assert mock_find.call_count == 2
+            mock_create.assert_called_once_with("my-repo", "rep-abc123")
+
+    def test_different_repos_with_same_name_use_different_identifiers(self):
+        """Test that repositories with the same name but different paths use different identifiers."""
+        with patch("auto_slopp.utils.vikunja_operations.find_project") as mock_find:
+            mock_find.return_value = {
+                "id": 1,
+                "title": "my-repo",
+                "identifier": "rep-abc123",
+            }
+
+            result1 = find_or_create_project("my-repo", "rep-abc123")
+            mock_find.assert_called_once_with("rep-abc123")
+
+            mock_find.reset_mock()
+            mock_find.return_value = {
+                "id": 2,
+                "title": "my-repo",
+                "identifier": "rep-def456",
+            }
+
+            result2 = find_or_create_project("my-repo", "rep-def456")
+            mock_find.assert_called_once_with("rep-def456")
+
+            assert result1["id"] != result2["id"]
+            assert result1["identifier"] == "rep-abc123"
+            assert result2["identifier"] == "rep-def456"
+
 
 class TestCreateTask:
     """Tests for create_task function."""

--- a/tests/test_vikunja_task_source.py
+++ b/tests/test_vikunja_task_source.py
@@ -21,7 +21,13 @@ class TestVikunjaTaskSource:
         tasks = task_source.get_tasks(Path("/test/repo"))
 
         assert tasks == []
-        mock_find_project.assert_called_once_with("repo")
+        # Check that find_or_create_project was called with correct arguments
+        # First argument is project name, second is generated identifier
+        mock_find_project.assert_called_once()
+        args, kwargs = mock_find_project.call_args
+        assert args[0] == "repo"  # project name
+        assert len(args[1]) == 10  # identifier should be 10 chars
+        assert args[1].startswith("rep-")  # identifier should start with rep-
 
     @patch("auto_slopp.workers.vikunja_task_source.get_open_tasks_by_project")
     @patch("auto_slopp.workers.vikunja_task_source.find_or_create_project")
@@ -338,3 +344,98 @@ class TestVikunjaTaskSource:
         assert comment_args[0] == 42
         assert "8/15" in comment_args[1]
         assert "Max iterations reached" in comment_args[1]
+
+    @patch("auto_slopp.workers.vikunja_task_source.find_or_create_project")
+    @patch("auto_slopp.workers.vikunja_task_source.get_open_tasks_by_project")
+    @patch("auto_slopp.workers.vikunja_task_source.verify_blocking_closed")
+    @patch("auto_slopp.workers.vikunja_task_source.settings")
+    def test_get_tasks_generates_consistent_project_identifier(
+        self, mock_settings, mock_verify, mock_get_tasks, mock_find_project
+    ):
+        """Test that get_tasks generates consistent project identifiers for the same repository."""
+        mock_settings.github_issue_worker_required_label = "test-tag"
+        mock_verify.return_value = True
+        mock_find_project.return_value = {"id": 1, "title": "Test Project"}
+        mock_get_tasks.return_value = []
+
+        task_source = VikunjaTaskSource()
+
+        # Call get_tasks twice with the same path
+        task_source.get_tasks(Path("/some/path/to/my-repo"))
+        first_call_args = mock_find_project.call_args
+
+        mock_find_project.reset_mock()
+        task_source.get_tasks(Path("/some/path/to/my-repo"))
+        second_call_args = mock_find_project.call_args
+
+        # Both calls should use the same project identifier
+        assert first_call_args == second_call_args
+        # The identifier should be derived from the repo name and a hash of the path
+        assert first_call_args[0][0] == "my-repo"  # project_name
+        assert len(first_call_args[0][1]) == 10  # project_identifier should be exactly 10 chars
+
+    @patch("auto_slopp.workers.vikunja_task_source.find_or_create_project")
+    @patch("auto_slopp.workers.vikunja_task_source.get_open_tasks_by_project")
+    @patch("auto_slopp.workers.vikunja_task_source.verify_blocking_closed")
+    @patch("auto_slopp.workers.vikunja_task_source.settings")
+    def test_get_tasks_generates_different_identifiers_for_different_repos(
+        self, mock_settings, mock_verify, mock_get_tasks, mock_find_project
+    ):
+        """Test that get_tasks generates different project identifiers for different repositories."""
+        mock_settings.github_issue_worker_required_label = "test-tag"
+        mock_verify.return_value = True
+        mock_find_project.return_value = {"id": 1, "title": "Test Project"}
+        mock_get_tasks.return_value = []
+
+        task_source = VikunjaTaskSource()
+
+        # Call get_tasks for two different paths with same repo name
+        task_source.get_tasks(Path("/path/to/my-repo"))
+        first_call_args = mock_find_project.call_args
+
+        mock_find_project.reset_mock()
+        task_source.get_tasks(Path("/different/path/to/my-repo"))
+        second_call_args = mock_find_project.call_args
+
+        # Both calls should use the same project name but different identifiers
+        assert first_call_args[0][0] == second_call_args[0][0] == "my-repo"  # same project_name
+        assert first_call_args[0][1] != second_call_args[0][1]  # different identifiers
+        assert len(first_call_args[0][1]) == len(second_call_args[0][1]) == 10  # both exactly 10 chars
+
+    @patch("auto_slopp.workers.vikunja_task_source.find_or_create_project")
+    @patch("auto_slopp.workers.vikunja_task_source.get_open_tasks_by_project")
+    @patch("auto_slopp.workers.vikunja_task_source.verify_blocking_closed")
+    @patch("auto_slopp.workers.vikunja_task_source.settings")
+    def test_get_tasks_identifier_length_and_format(
+        self, mock_settings, mock_verify, mock_get_tasks, mock_find_project
+    ):
+        """Test that get_tasks generates identifiers with correct length and format."""
+        mock_settings.github_issue_worker_required_label = "test-tag"
+        mock_verify.return_value = True
+        mock_find_project.return_value = {"id": 1, "title": "Test Project"}
+        mock_get_tasks.return_value = []
+
+        task_source = VikunjaTaskSource()
+
+        # Test with various path lengths
+        test_paths = [
+            Path("/a/b"),  # short path
+            Path("/very/long/path/with/many/components/that/might/cause/issues"),  # long path
+            Path("/repo-with-dashes_and_underscores"),  # special chars
+        ]
+
+        for test_path in test_paths:
+            mock_find_project.reset_mock()
+            task_source.get_tasks(test_path)
+            call_args = mock_find_project.call_args
+
+            # Identifier should always be exactly 10 characters
+            assert len(call_args[0][1]) == 10, f"Identifier length incorrect for path {test_path}"
+            # Identifier should only contain lowercase letters, numbers, and hyphens
+            identifier = call_args[0][1]
+            assert all(c.isalnum() or c == "-" for c in identifier), f"Invalid characters in identifier {identifier}"
+            # Should start with repo name prefix (first 3 chars of repo name)
+            expected_prefix = test_path.name[:3].lower()
+            assert identifier.startswith(
+                expected_prefix
+            ), f"Identifier {identifier} doesn't start with prefix {expected_prefix}"


### PR DESCRIPTION
## Summary

Fixed the VikunjaTaskSource to correctly map repositories to Vikunja projects using a unique identifier based on the full repository path instead of just the repository name.

## Changes Implemented

1. **Modified VikunjaTaskSource.get_tasks()** - Added logic to generate a unique project identifier using MD5 hash of the absolute repository path. The identifier format is `{first_3_chars_of_repo_name}-{first_6_chars_of_md5_hash}` (10 characters total), forced to lowercase.

2. **Updated find_or_create_project call** - Now passes both `project_name` (for display) and `project_identifier` (for uniqueness) as separate parameters.

3. **Added unit tests** - Created tests that verify:
   - Same repository always maps to the same project
   - Different repositories map to different projects
   - Edge cases like very long paths
   - Identifier length and format requirements

## Test Verification

Ran `make test` - All tests passed including:
- New unit tests for repository-to-project mapping
- Existing tests with no regressions

The implementation ensures different repositories with the same name get different project identifiers in Vikunja.

Closes #339