### PR TITLE
fix: replace --branch flag with SHA-based filtering in get_workflow_r…

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -657,14 +657,25 @@ def get_workflow_runs_for_branch(repo_dir: Path, branch: str, event: Optional[st
             List of dictionaries containing workflow run information (conclusion, workflowName, etc.)
         """
         try:
+            # Get the SHA of the branch to filter by
+            sha_result = subprocess.run(
+                ["git", "rev-parse", f"origin/{branch}"],
+                cwd=repo_dir,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if sha_result.returncode != 0:
+                logger.warning(f"Could not resolve origin/{branch} SHA for workflow run lookup")
+                return []
+            branch_sha = sha_result.stdout.strip()
+
             result = _run_gh_command(
                 repo_dir,
                 "run",
                 "list",
-                "--branch",
-                branch,
                 "--limit",
-                "10",
+                "20",
                 "--json",
                 "conclusion,workflowName,headSha,event,status,databaseId",
                 check=False,
@@ -676,10 +687,11 @@ def get_workflow_runs_for_branch(repo_dir: Path, branch: str, event: Optional[st
                 return []
 
             runs = json.loads(result.stdout)
+            # Filter by branch SHA since gh run list doesn't support --branch flag
+            filtered_runs = [run for run in runs if run.get("headSha") == branch_sha]
             if event:
-                filtered_runs = [run for run in runs if run.get("event") == event]
-                return filtered_runs
-            return runs
+                filtered_runs = [run for run in filtered_runs if run.get("event") == event]
+            return filtered_runs
 
         except GitHubOperationError as e:
             logger.error(f"Error getting workflow runs for branch {branch} from {repo_dir.name}: {str(e)}")

--- a/tests/test_github_operations.py
+++ b/tests/test_github_operations.py
@@ -124,8 +124,10 @@ class TestGetWorkflowRunsForBranch:
     """Test cases for get_workflow_runs_for_branch function."""
 
     @patch("auto_slopp.utils.github_operations._run_gh_command")
-    def test_get_workflow_runs_for_branch_success(self, mock_run_gh):
+    @patch("auto_slopp.utils.github_operations.subprocess.run")
+    def test_get_workflow_runs_for_branch_success(self, mock_subprocess_run, mock_run_gh):
         """Test successful retrieval of workflow runs for branch."""
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout="abc123")
         mock_run_gh.return_value = Mock(
             returncode=0,
             stdout='[{"conclusion": "success", "workflowName": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}]',
@@ -141,8 +143,10 @@ class TestGetWorkflowRunsForBranch:
         assert result[0]["databaseId"] == 123
 
     @patch("auto_slopp.utils.github_operations._run_gh_command")
-    def test_get_workflow_runs_for_branch_with_event_filter(self, mock_run_gh):
+    @patch("auto_slopp.utils.github_operations.subprocess.run")
+    def test_get_workflow_runs_for_branch_with_event_filter(self, mock_subprocess_run, mock_run_gh):
         """Test retrieval of workflow runs for branch with event filter."""
+        mock_subprocess_run.return_value = Mock(returncode=0, stdout="abc123")
         mock_run_gh.return_value = Mock(
             returncode=0,
             stdout='[{"conclusion": "success", "workflowName": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}, {"conclusion": "failure", "workflowName": "Lint", "headSha": "def456", "event": "push", "status": "completed", "databaseId": 124}]',


### PR DESCRIPTION
…uns_for_branch

The gh run list CLI command does not support the --branch flag, causing workflow run lookups to fail. Fix by resolving the branch SHA via git rev-parse and filtering runs client-side by headSha.