### PR TITLE
fix: resolve log errors - use correct GitHub API field name and add C…

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -654,7 +654,7 @@ def get_workflow_runs_for_branch(repo_dir: Path, branch: str, event: Optional[st
             event: Optional event filter (e.g., 'pull_request')
 
         Returns:
-            List of dictionaries containing workflow run information (conclusion, workflowName, etc.)
+            List of dictionaries containing workflow run information (conclusion, name, etc.)
         """
         try:
             # Get the SHA of the branch to filter by
@@ -677,7 +677,7 @@ def get_workflow_runs_for_branch(repo_dir: Path, branch: str, event: Optional[st
                 "--limit",
                 "20",
                 "--json",
-                "conclusion,workflowName,headSha,event,status,databaseId",
+                "conclusion,name,headSha,event,status,databaseId",
                 check=False,
             )
 

--- a/src/auto_slopp/workers/pr_worker.py
+++ b/src/auto_slopp/workers/pr_worker.py
@@ -260,7 +260,7 @@ class PRWorker(Worker):
         for run in runs:
             conclusion = run.get("conclusion")
             status = run.get("status")
-            workflow_name = run.get("workflowName")
+            workflow_name = run.get("name")
             database_id = run.get("databaseId")
             
             # Log the workflow run details
@@ -314,7 +314,7 @@ class PRWorker(Worker):
         all_success = True
         for run in runs:
             conclusion = run.get("conclusion")
-            workflow_name = run.get("workflowName")
+            workflow_name = run.get("name")
             if conclusion:
                 self.logger.info(
                     f"Workflow run for branch {branch}: workflow '{workflow_name}' concluded with '{conclusion}'"

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -33,7 +33,7 @@ class CLIConfiguration(BaseModel):
         description="Capability rating of this CLI tool (0-10)",
     )
     cooldown_seconds: int = Field(
-        default=3600,
+        default=60,
         description="Cooldown time in seconds if the tool encounters errors",
     )
     name: str = Field(
@@ -121,6 +121,23 @@ class Settings(BaseSettings):
                 ],
                 capability=6,
                 name="pi Qwen3.6-35B-A3B",
+            ),
+            CLIConfiguration(
+                cli_command="codex",
+                cli_args=[
+                    "--dangerously-bypass-approvals-and-sandbox",
+                    "exec",
+                ],
+                capability=6,
+                name="codex exec",
+            ),
+            CLIConfiguration(
+                cli_command="opencode",
+                cli_args=[
+                    "run",
+                ],
+                capability=6,
+                name="opencode run",
             ),
         ],
         description=(

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -123,20 +123,20 @@ class Settings(BaseSettings):
                 name="pi Qwen3.6-35B-A3B",
             ),
             CLIConfiguration(
-                cli_command="codex",
+                cli_command="pi",
                 cli_args=[
-                    "--dangerously-bypass-approvals-and-sandbox",
-                    "exec",
+                    "--model",
+                    "llama-cpp/North-Mini-Code",
                 ],
-                capability=6,
-                name="codex exec",
+                capability=5,
+                name="pi North-Mini-Code",
             ),
             CLIConfiguration(
                 cli_command="opencode",
                 cli_args=[
                     "run",
                 ],
-                capability=6,
+                capability=4,
                 name="opencode run",
             ),
         ],

--- a/src/settings/main.py
+++ b/src/settings/main.py
@@ -33,7 +33,7 @@ class CLIConfiguration(BaseModel):
         description="Capability rating of this CLI tool (0-10)",
     )
     cooldown_seconds: int = Field(
-        default=60,
+        default=3600,
         description="Cooldown time in seconds if the tool encounters errors",
     )
     name: str = Field(
@@ -73,7 +73,7 @@ class Settings(BaseSettings):
         return v
 
     executor_sleep_interval: float = Field(
-        default=60.0,
+        default=600.0,
         description="Sleep interval between executor iterations in seconds",
     )
 
@@ -146,7 +146,7 @@ class Settings(BaseSettings):
     )
 
     slop_timeout: int = Field(
-        default=7200,
+        default=10000,
         description="Timeout for slopmachine execution in seconds (default: 2 hours)",
     )
 

--- a/tests/test_github_operations.py
+++ b/tests/test_github_operations.py
@@ -130,13 +130,13 @@ class TestGetWorkflowRunsForBranch:
         mock_subprocess_run.return_value = Mock(returncode=0, stdout="abc123")
         mock_run_gh.return_value = Mock(
             returncode=0,
-            stdout='[{"conclusion": "success", "workflowName": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}]',
+            stdout='[{"conclusion": "success", "name": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}]',
         )
         repo_dir = Path("/tmp/test_repo")
         result = get_workflow_runs_for_branch(repo_dir, "main")
         assert len(result) == 1
         assert result[0]["conclusion"] == "success"
-        assert result[0]["workflowName"] == "CI"
+        assert result[0]["name"] == "CI"
         assert result[0]["headSha"] == "abc123"
         assert result[0]["event"] == "pull_request"
         assert result[0]["status"] == "completed"
@@ -149,7 +149,7 @@ class TestGetWorkflowRunsForBranch:
         mock_subprocess_run.return_value = Mock(returncode=0, stdout="abc123")
         mock_run_gh.return_value = Mock(
             returncode=0,
-            stdout='[{"conclusion": "success", "workflowName": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}, {"conclusion": "failure", "workflowName": "Lint", "headSha": "def456", "event": "push", "status": "completed", "databaseId": 124}]',
+            stdout='[{"conclusion": "success", "name": "CI", "headSha": "abc123", "event": "pull_request", "status": "completed", "databaseId": 123}, {"conclusion": "failure", "name": "Lint", "headSha": "def456", "event": "push", "status": "completed", "databaseId": 124}]',
         )
         repo_dir = Path("/tmp/test_repo")
         result = get_workflow_runs_for_branch(repo_dir, "main", event="pull_request")

--- a/tests/test_pr_worker.py
+++ b/tests/test_pr_worker.py
@@ -285,7 +285,7 @@ class TestPRWorkerWorkflowRuns:
         mock_get_workflow_runs.return_value = [
             {
                 "conclusion": "success",
-                "workflowName": "CI",
+                "name": "CI",
                 "headSha": "abc123",
                 "event": "pull_request",
                 "status": "completed",
@@ -293,7 +293,7 @@ class TestPRWorkerWorkflowRuns:
             },
             {
                 "conclusion": "success",
-                "workflowName": "Lint",
+                "name": "Lint",
                 "headSha": "def456",
                 "event": "pull_request",
                 "status": "completed",
@@ -313,7 +313,7 @@ class TestPRWorkerWorkflowRuns:
         mock_get_workflow_runs.return_value = [
             {
                 "conclusion": "success",
-                "workflowName": "CI",
+                "name": "CI",
                 "headSha": "abc123",
                 "event": "pull_request",
                 "status": "completed",
@@ -321,7 +321,7 @@ class TestPRWorkerWorkflowRuns:
             },
             {
                 "conclusion": "failure",
-                "workflowName": "Lint",
+                "name": "Lint",
                 "headSha": "def456",
                 "event": "pull_request",
                 "status": "completed",
@@ -332,7 +332,7 @@ class TestPRWorkerWorkflowRuns:
         result = worker._get_and_log_workflow_runs(repo_dir, "main")
         assert len(result) == 1
         assert result[0]["conclusion"] == "failure"
-        assert result[0]["workflowName"] == "Lint"
+        assert result[0]["name"] == "Lint"
 
     @patch("auto_slopp.workers.pr_worker.get_workflow_runs_for_branch")
     def test_get_and_log_workflow_runs_with_in_progress(self, mock_get_workflow_runs):
@@ -343,7 +343,7 @@ class TestPRWorkerWorkflowRuns:
         mock_get_workflow_runs.return_value = [
             {
                 "conclusion": None,
-                "workflowName": "CI",
+                "name": "CI",
                 "headSha": "abc123",
                 "event": "pull_request",
                 "status": "in_progress",
@@ -351,7 +351,7 @@ class TestPRWorkerWorkflowRuns:
             },
             {
                 "conclusion": "success",
-                "workflowName": "Lint",
+                "name": "Lint",
                 "headSha": "def456",
                 "event": "pull_request",
                 "status": "completed",
@@ -371,7 +371,7 @@ class TestPRWorkerWorkflowRuns:
         mock_get_workflow_runs.return_value = [
             {
                 "conclusion": None,
-                "workflowName": "CI",
+                "name": "CI",
                 "headSha": "abc123",
                 "event": "pull_request",
                 "status": "queued",
@@ -379,7 +379,7 @@ class TestPRWorkerWorkflowRuns:
             },
             {
                 "conclusion": "success",
-                "workflowName": "Lint",
+                "name": "Lint",
                 "headSha": "def456",
                 "event": "pull_request",
                 "status": "completed",


### PR DESCRIPTION
…LI fallbacks

- Fix workflow runs API call: change 'workflowName' to 'name' (gh run list returns 'name')
- Fix PR worker to use 'name' field instead of 'workflowName'
- Update tests to match corrected field name
- Add codex and opencode as fallback CLI configurations
- Reduce default cooldown from 3600s to 60s for faster recovery
- Fixes: No CLI configuration available error and 'Unknown JSON field: workflowName' error