### PR TITLE
fix: condense ALL comments in _condense_comments() (not just author's)

### DIFF
--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -71,11 +71,10 @@ class GitHubTaskSource(TaskSource):
     def _condense_comments(self, repo_path: Path, issue_number: int, issue_author_login: str) -> List[str]:
         """Condense all comments (except the issue description) into a single comment.
 
-        Fetches all comments via get_issue_comments(). If there are 0 or 1 comments
-        from the issue author, returns them as-is (no condensing). If there are 2+
-        comments from the issue author, calls the CLI executor to summarize them,
-        posts the summary as a new comment, deletes the original comments, and returns
-        the summary as a single-element list.
+        Fetches all comments via get_issue_comments(). If there are 0 or 1 comments,
+        returns them as-is (no condensing). If there are 2+ comments, calls the CLI
+        executor to summarize them, posts the summary as a new comment, deletes the
+        original comments, and returns the summary as a single-element list.
 
         Args:
             repo_path: Path to the repository.
@@ -83,53 +82,41 @@ class GitHubTaskSource(TaskSource):
             issue_author_login: Login of the issue author.
 
         Returns:
-            List containing either [] (no comments), [single_comment_body] (one comment
-            from the issue author), or [condensed_summary] (multiple comments from the
-            issue author condensed).
+            List containing either [] (no comments), [single_comment_body] (one comment),
+            or [condensed_summary] (multiple comments condensed).
         """
         # Fetch all comments (each is a dict with 'id', 'body', 'author', 'createdAt')
         all_comments = get_issue_comments(repo_path, issue_number)
-        # Filter to only comments from the issue author
-        author_comments = []
-        for comment in all_comments:
-            author = comment.get("author")
-            if isinstance(author, dict):
-                author_login = author.get("login")
-            else:
-                # Assume author is a string login
-                author_login = author
-            if author_login == issue_author_login:
-                author_comments.append(comment)
-        # No comments from author
-        if not author_comments:
+        # No comments at all
+        if not all_comments:
             return []
-        # Single comment from author: return its body as a single-element list (no condensing)
-        if len(author_comments) == 1:
-            return [author_comments[0].get("body", "") or ""]
-        # Two or more comments from author: condense
+        # Single comment: return its body as a single-element list (no condensing)
+        if len(all_comments) == 1:
+            return [all_comments[0].get("body", "") or ""]
+        # Two or more comments: condense ALL comments
         # Prepare prompt for the CLI executor
         comment_lines = []
-        for i, comment in enumerate(author_comments, start=1):
+        for i, comment in enumerate(all_comments, start=1):
             body = comment.get("body", "") or ""
             comment_lines.append(f"Comment {i}:{body}")
         prompt = "\n".join(comment_lines)
         # Execute condensation
         result = execute_with_instructions(
             instructions=prompt,
-            work_dir=str(repo_path),
+            work_dir=repo_path,
             agent_args=[],
             task_name="default",
         )
         condensed = ""
-        if result and getattr(result, "stdout", None):
-            condensed = result.stdout.strip()
+        if result and result.get("stdout"):
+            condensed = result["stdout"].strip()
         # If condensation produced empty string, fallback to joining with separator
         if not condensed:
-            condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in author_comments])
+            condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in all_comments])
         # Post the condensed summary as a new comment
         comment_on_issue(repo_path, issue_number, condensed)
-        # Delete each original comment from author
-        for comment in author_comments:
+        # Delete each original comment
+        for comment in all_comments:
             cid = comment.get("id")
             if cid is not None:
                 delete_issue_comment(repo_path, issue_number, cid)

--- a/src/auto_slopp/workers/issue_worker.py
+++ b/src/auto_slopp/workers/issue_worker.py
@@ -193,22 +193,6 @@ class IssueWorker(Worker):
         task_title = task.title
         task_body = task.body
 
-        # Condense comments: we want to end up with exactly one comment that is the condensation of
-        # all comments except the first one. If there are no comments or only one comment, we
-        # provide a placeholder.
-        original_comment_count = len(task.comments)
-        if original_comment_count == 0:
-            task.comments = ["No comments provided."]
-            self.logger.info(f"No comments found for task #{task_id}, set to placeholder.")
-        elif original_comment_count == 1:
-            task.comments = ["Only one comment present; no additional comments to condense."]
-            self.logger.info(f"Only one comment for task #{task_id}, set to placeholder.")
-        else:
-            # Condense all comments except the first one
-            condensed = "\\n\\n---\\n\\n".join(task.comments[1:])
-            task.comments = [condensed]
-            self.logger.info(f"Condensed {original_comment_count - 1} comments into one for task #{task_id}.")
-
         self.logger.info(f"Processing task #{task_id}: {task_title}")
 
         result = {

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -239,6 +239,148 @@ class TestGitHubTaskSource:
         mock_execute.assert_called_once()
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_get_tasks_single_comment_no_condensing(self, mock_settings, mock_get_comments, mock_get_issues):
+        """Test that a single comment is returned as-is without condensing."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        mock_get_comments.return_value = [
+            {"author": "test-user", "body": "Single comment", "id": 1},
+        ]
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert len(task.comments) == 1
+        assert task.comments[0] == "Single comment"
+
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_get_tasks_empty_condensation_fallback(
+        self, mock_settings, mock_execute, mock_get_comments, mock_get_issues
+    ):
+        """Test fallback when condensation produces empty result."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        mock_get_comments.return_value = [
+            {"author": "test-user", "body": "Comment 1", "id": 1},
+            {"author": "other-user", "body": "Comment 2", "id": 2},
+        ]
+        mock_execute.return_value = {"stdout": "", "success": True}
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert len(task.comments) == 1
+        assert task.comments[0] == "Comment 1\n\n---\n\nComment 2"
+
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_get_tasks_execute_with_instructions_called_with_path(
+        self, mock_settings, mock_execute, mock_get_comments, mock_get_issues
+    ):
+        """Test that execute_with_instructions is called with Path object for work_dir."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        mock_get_comments.return_value = [
+            {"author": "test-user", "body": "Comment 1", "id": 1},
+            {"author": "other-user", "body": "Comment 2", "id": 2},
+        ]
+        mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        mock_execute.assert_called_once()
+        call_args = mock_execute.call_args
+        assert call_args.kwargs["work_dir"] == Path("/test")
+        assert isinstance(call_args.kwargs["work_dir"], Path)
+
+    @patch("auto_slopp.workers.github_task_source.delete_issue_comment")
+    @patch("auto_slopp.workers.github_task_source.comment_on_issue")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_condense_comments_posts_summary_and_deletes_originals(
+        self, mock_settings, mock_get_comments, mock_get_issues, mock_execute, mock_comment, mock_delete
+    ):
+        """Test that _condense_comments() posts a summary to GitHub and deletes original comments."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        mock_get_comments.return_value = [
+            {"author": "test-user", "body": "Comment 1", "id": 100},
+            {"author": "other-user", "body": "Comment 2", "id": 200},
+        ]
+        mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        assert tasks[0].comments == ["Condensed summary"]
+        # Verify the condensed summary was posted as a new comment
+        mock_comment.assert_called_once_with(Path("/test"), 1, "Condensed summary")
+        # Verify each original comment was deleted
+        assert mock_delete.call_count == 2
+        mock_delete.assert_any_call(Path("/test"), 1, 100)
+        mock_delete.assert_any_call(Path("/test"), 1, 200)
+
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
     def test_get_tasks_returns_empty_on_no_issues(self, mock_get_issues):
         """Test that get_tasks returns empty list when no issues found."""
         mock_get_issues.return_value = []

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -206,9 +206,10 @@ class TestGitHubTaskSource:
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
     @patch("auto_slopp.workers.github_task_source.settings")
-    def test_get_tasks_filters_comments_by_author(self, mock_settings, mock_get_comments, mock_get_issues):
-        """Test that only author's comments are included in task comments."""
+    def test_get_tasks_condenses_all_comments(self, mock_settings, mock_execute, mock_get_comments, mock_get_issues):
+        """Test that ALL comments are condensed into a single comment."""
         mock_settings.github_issue_worker_required_label = "test-label"
         mock_settings.github_issue_worker_allowed_creator = "test-user"
 
@@ -223,9 +224,10 @@ class TestGitHubTaskSource:
         ]
         mock_get_issues.return_value = mock_issues
         mock_get_comments.return_value = [
-            {"author": "test-user", "body": "Author comment"},
-            {"author": "other-user", "body": "Other comment"},
+            {"author": "test-user", "body": "Author comment", "id": 1},
+            {"author": "other-user", "body": "Other comment", "id": 2},
         ]
+        mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
 
         task_source = GitHubTaskSource()
         tasks = task_source.get_tasks(Path("/test"))
@@ -233,7 +235,8 @@ class TestGitHubTaskSource:
         assert len(tasks) == 1
         task = tasks[0]
         assert len(task.comments) == 1
-        assert task.comments[0] == "Author comment"
+        assert task.comments[0] == "Condensed summary"
+        mock_execute.assert_called_once()
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     def test_get_tasks_returns_empty_on_no_issues(self, mock_get_issues):

--- a/tests/test_issue_worker.py
+++ b/tests/test_issue_worker.py
@@ -1002,26 +1002,3 @@ class TestIssueWorker:
         assert task_source.on_task_complete_called is True
         mock_push.assert_called_once()
         mock_create_pr.assert_called_once()
-
-    def test_comment_condensation(self):
-        """Test that comments are properly condensed according to the rules."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Test case 1: No comments
-            task_source = MockTaskSource(tasks=[Task(id=1, title="Test", body="", comments=[])])
-            worker = IssueWorker(task_source=task_source, dry_run=True)
-            worker.run(Path(temp_dir))
-            assert task_source.tasks[0].comments == ["No comments provided."]
-
-            # Test case 2: One comment
-            task_source = MockTaskSource(tasks=[Task(id=2, title="Test", body="", comments=["Only comment"])])
-            worker = IssueWorker(task_source=task_source, dry_run=True)
-            worker.run(Path(temp_dir))
-            assert task_source.tasks[0].comments == ["Only one comment present; no additional comments to condense."]
-
-            # Test case 3: Multiple comments
-            comments = ["First comment", "Second comment", "Third comment"]
-            task_source = MockTaskSource(tasks=[Task(id=3, title="Test", body="", comments=comments)])
-            worker = IssueWorker(task_source=task_source, dry_run=True)
-            worker.run(Path(temp_dir))
-            expected = "Second comment\\n\\n---\\n\\nThird comment"
-            assert task_source.tasks[0].comments == [expected]

--- a/tests/test_issue_worker.py
+++ b/tests/test_issue_worker.py
@@ -571,6 +571,73 @@ class TestIssueWorker:
         assert task_source.on_no_changes_called is True
         assert task_source.on_task_complete_called is False
 
+    @patch("auto_slopp.workers.issue_worker.commit_and_push_changes")
+    @patch("auto_slopp.workers.issue_worker.checkout_branch_resilient")
+    @patch("auto_slopp.workers.issue_worker.create_and_checkout_branch")
+    @patch("auto_slopp.workers.issue_worker.has_changes")
+    @patch("auto_slopp.workers.issue_worker.get_current_branch")
+    @patch("auto_slopp.workers.issue_worker.settings")
+    @patch("auto_slopp.workers.issue_worker.push_to_remote")
+    @patch("auto_slopp.workers.issue_worker.create_pull_request")
+    @patch("auto_slopp.workers.issue_worker.get_pr_for_branch")
+    @patch("auto_slopp.workers.issue_worker.execute_with_instructions")
+    @patch("auto_slopp.workers.issue_worker.get_active_cli_command")
+    @patch("auto_slopp.workers.issue_worker.get_commits_ahead_of_branch")
+    def test_process_single_task_passes_condensed_comments_directly(
+        self,
+        mock_commits_ahead,
+        mock_cli,
+        mock_execute,
+        mock_get_pr,
+        mock_create_pr,
+        mock_push,
+        mock_settings,
+        mock_current_branch,
+        mock_has_changes,
+        mock_create_branch,
+        mock_checkout,
+        mock_commit_push,
+    ):
+        """Test that _process_single_task() passes task.comments directly without re-condensing or replacing with placeholder.
+
+        When GitHubTaskSource._condense_comments() returns [condensed_summary], the worker
+        should pass this directly to the agent without modification. The old fallback logic
+        that replaced task.comments with a placeholder like
+        'Only one comment present; no additional comments to condense.' has been removed.
+        """
+        mock_commits_ahead.return_value = 1
+        mock_cli.return_value = "opencode"
+        mock_settings.ralph_enabled = False
+        mock_commit_push.return_value = (True, None)
+        mock_checkout.return_value = True
+        mock_create_branch.return_value = True
+        mock_execute.return_value = {"success": True}
+        mock_has_changes.return_value = True
+        mock_current_branch.return_value = "ai/task-1"
+        mock_push.return_value = (True, "")
+        mock_get_pr.return_value = None
+        mock_create_pr.return_value = {"url": "https://github.com/test/pr/1"}
+
+        # Simulate a task where comments have already been condensed by GitHubTaskSource
+        # This is what happens when _condense_comments() returns [condensed_summary]
+        condensed_comment = "Condensed summary of all comments from multiple authors"
+        task = Task(id=1, title="Test", body="Test body", comments=[condensed_comment])
+        task_source = MockTaskSource(tasks=[task])
+        worker = IssueWorker(task_source=task_source, dry_run=False)
+        result = worker.run(Path("/tmp"))
+
+        assert result["success"] is True
+        assert result["tasks_processed"] == 1
+        # Verify execute_with_instructions was called
+        mock_execute.assert_called_once()
+        # Verify the instructions contain the condensed comment (not a placeholder)
+        call_args = mock_execute.call_args
+        instructions = call_args.args[0]
+        assert condensed_comment in instructions
+        # Verify no placeholder text was used
+        assert "Only one comment present" not in instructions
+        assert "no additional comments to condense" not in instructions
+
     @patch("auto_slopp.workers.issue_worker.checkout_branch_resilient")
     @patch("auto_slopp.workers.issue_worker.create_and_checkout_branch")
     @patch("auto_slopp.workers.issue_worker.settings")

--- a/tests/test_task_source.py
+++ b/tests/test_task_source.py
@@ -205,8 +205,13 @@ class TestGitHubTaskSource:
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.comment_on_issue")
+    @patch("auto_slopp.workers.github_task_source.delete_issue_comment")
     @patch("auto_slopp.workers.github_task_source.settings")
-    def test_get_tasks_returns_correct_task_objects(self, mock_settings, mock_comments, mock_issues):
+    def test_get_tasks_returns_correct_task_objects(
+        self, mock_settings, mock_delete, mock_comment, mock_execute, mock_comments, mock_issues
+    ):
         """Test that get_tasks returns properly structured Task objects."""
         mock_settings.github_issue_worker_required_label = "ai"
         mock_settings.github_issue_worker_allowed_creator = "testuser"
@@ -223,13 +228,14 @@ class TestGitHubTaskSource:
             {"author": "testuser", "body": "Comment 1"},
             {"author": "otheruser", "body": "Comment 2"},
         ]
+        mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
         source = GitHubTaskSource()
         tasks = source.get_tasks(Path("/tmp"))
         assert len(tasks) == 1
         assert tasks[0].id == 42
         assert tasks[0].title == "Test Issue"
         assert tasks[0].body == "Test Body"
-        assert tasks[0].comments == ["Comment 1"]
+        assert tasks[0].comments == ["Condensed summary"]
         assert tasks[0].raw["number"] == 42
 
     def test_get_branch_name_generates_correct_format(self):


### PR DESCRIPTION
- Pass Path object instead of string to execute_with_instructions
- Use result.get('stdout') instead of getattr for dict result
- Update test to verify ALL comments are condensed
Closes https://github.com/MelvinKl/Auto-slopp/issues/376