### PR TITLE
#384: Comments compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,10 @@ AUTO_SLOPP_DEBUG=false
 AUTO_SLOPP_WORKERS_DISABLED='[]'
 # Example: AUTO_SLOPP_WORKERS_DISABLED='["GitHubIssueWorker"]'
 
+# GitHub Issue Worker configuration
+AUTO_SLOPP_GITHUB_ISSUE_WORKER_REQUIRED_LABEL=ai        # Required label for issues to be processed (default: "ai")
+AUTO_SLOPP_GITHUB_ISSUE_WORKER_ALLOWED_CREATOR=MelvinKl  # Whitelisted GitHub username whose comments are included in condensation (default: "MelvinKl")
+
 # Stale branch cleanup: days before a local-only branch is deleted (default: 1)
 AUTO_SLOPP_STALE_BRANCH_DAYS_THRESHOLD=1
 
@@ -762,6 +766,9 @@ vikunja_worker = IssueWorker(task_source=VikunjaTaskSource())
 
 ### GitHubIssueWorker
 Convenience wrapper around IssueWorker configured with GitHubTaskSource. Handles GitHub issue operations.
+
+**Comment Condensation**: When processing GitHub issues, Auto-slopp condenses comments from the issue author and/or the whitelisted `allowed_creator` into a single summary comment. Comments from other users are ignored. After condensation, the original comments from the author/allowed creator are deleted and replaced with the summary.
+
 ```python
 from auto_slopp.workers import GitHubIssueWorker
 

--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -134,8 +134,8 @@ class GitHubTaskSource(TaskSource):
             condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in filtered_comments])
         # Post the condensed summary as a new comment
         comment_on_issue(repo_path, issue_number, condensed)
-        # Delete ALL original comments (not just filtered ones)
-        for comment in all_comments:
+        # Delete only the filtered comments (from issue author or allowed creator)
+        for comment in filtered_comments:
             cid = comment.get("id")
             if cid is not None:
                 delete_issue_comment(repo_path, issue_number, cid)

--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -69,12 +69,14 @@ class GitHubTaskSource(TaskSource):
         return tasks
 
     def _condense_comments(self, repo_path: Path, issue_number: int, issue_author_login: str) -> List[str]:
-        """Condense all comments (except the issue description) into a single comment.
+        """Condense comments from the issue author or allowed creator into a single comment.
 
-        Fetches all comments via get_issue_comments(). If there are 0 or 1 comments,
-        returns them as-is (no condensing). If there are 2+ comments, calls the CLI
-        executor to summarize them, posts the summary as a new comment, deletes the
-        original comments, and returns the summary as a single-element list.
+        Fetches all comments via get_issue_comments(). Filters to only include comments
+        from the issue author or the whitelisted allowed creator. If there are 0 or 1
+        filtered comments, returns them as-is (no condensing). If there are 2+ filtered
+        comments, calls the CLI executor to summarize them, posts the summary as a new
+        comment, deletes the original filtered comments, and returns the summary as a
+        single-element list.
 
         Args:
             repo_path: Path to the repository.
@@ -87,16 +89,30 @@ class GitHubTaskSource(TaskSource):
         """
         # Fetch all comments (each is a dict with 'id', 'body', 'author', 'createdAt')
         all_comments = get_issue_comments(repo_path, issue_number)
-        # No comments at all
         if not all_comments:
             return []
-        # Single comment: return its body as a single-element list (no condensing)
-        if len(all_comments) == 1:
-            return [all_comments[0].get("body", "") or ""]
-        # Two or more comments: condense ALL comments
-        # Prepare prompt for the CLI executor
+
+        # Filter comments to only include those from issue author or allowed creator
+        allowed_creator = settings.github_issue_worker_allowed_creator
+        filtered_comments = []
+        for comment in all_comments:
+            author = comment.get("author")
+            if isinstance(author, dict):
+                author_login = author.get("login")
+            else:
+                author_login = author
+            if author_login in (issue_author_login, allowed_creator):
+                filtered_comments.append(comment)
+
+        # No relevant comments
+        if not filtered_comments:
+            return []
+        # Single relevant comment: return its body as-is (no condensing)
+        if len(filtered_comments) == 1:
+            return [filtered_comments[0].get("body", "") or ""]
+        # Two or more relevant comments: condense them
         comment_lines = []
-        for i, comment in enumerate(all_comments, start=1):
+        for i, comment in enumerate(filtered_comments, start=1):
             body = comment.get("body", "") or ""
             comment_lines.append(f"Comment {i}:{body}")
         prompt = "\n".join(comment_lines)
@@ -112,11 +128,11 @@ class GitHubTaskSource(TaskSource):
             condensed = result["stdout"].strip()
         # If condensation produced empty string, fallback to joining with separator
         if not condensed:
-            condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in all_comments])
+            condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in filtered_comments])
         # Post the condensed summary as a new comment
         comment_on_issue(repo_path, issue_number, condensed)
-        # Delete each original comment
-        for comment in all_comments:
+        # Delete each original filtered comment
+        for comment in filtered_comments:
             cid = comment.get("id")
             if cid is not None:
                 delete_issue_comment(repo_path, issue_number, cid)

--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -55,7 +55,8 @@ class GitHubTaskSource(TaskSource):
             issue_body = issue.get("body", "") or ""
 
             issue_author_login = issue.get("author", {}).get("login", "") if issue.get("author") else ""
-            comment_texts = self._condense_comments(repo_path, issue_number, issue_author_login)
+            allowed_creator = settings.github_issue_worker_allowed_creator
+            comment_texts = self._condense_comments(repo_path, issue_number, issue_author_login, allowed_creator)
 
             task = Task(
                 id=issue_number,
@@ -68,7 +69,9 @@ class GitHubTaskSource(TaskSource):
 
         return tasks
 
-    def _condense_comments(self, repo_path: Path, issue_number: int, issue_author_login: str) -> List[str]:
+    def _condense_comments(
+        self, repo_path: Path, issue_number: int, issue_author_login: str, allowed_creator: str
+    ) -> List[str]:
         """Condense comments from the issue author or allowed creator into a single comment.
 
         Fetches all comments via get_issue_comments(). Filters to only include comments
@@ -82,6 +85,7 @@ class GitHubTaskSource(TaskSource):
             repo_path: Path to the repository.
             issue_number: Issue number.
             issue_author_login: Login of the issue author.
+            allowed_creator: Whitelisted GitHub username whose comments should be included.
 
         Returns:
             List containing either [] (no comments), [single_comment_body] (one comment),
@@ -93,7 +97,6 @@ class GitHubTaskSource(TaskSource):
             return []
 
         # Filter comments to only include those from issue author or allowed creator
-        allowed_creator = settings.github_issue_worker_allowed_creator
         filtered_comments = []
         for comment in all_comments:
             author = comment.get("author")

--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -75,7 +75,7 @@ class GitHubTaskSource(TaskSource):
         from the issue author or the whitelisted allowed creator. If there are 0 or 1
         filtered comments, returns them as-is (no condensing). If there are 2+ filtered
         comments, calls the CLI executor to summarize them, posts the summary as a new
-        comment, deletes the original filtered comments, and returns the summary as a
+        comment, deletes ALL original comments on the issue, and returns the summary as a
         single-element list.
 
         Args:
@@ -131,8 +131,8 @@ class GitHubTaskSource(TaskSource):
             condensed = "\n\n---\n\n".join([c.get("body", "") or "" for c in filtered_comments])
         # Post the condensed summary as a new comment
         comment_on_issue(repo_path, issue_number, condensed)
-        # Delete each original filtered comment
-        for comment in filtered_comments:
+        # Delete ALL original comments (not just filtered ones)
+        for comment in all_comments:
             cid = comment.get("id")
             if cid is not None:
                 delete_issue_comment(repo_path, issue_number, cid)

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -351,10 +351,10 @@ class TestGitHubTaskSource:
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")
     @patch("auto_slopp.workers.github_task_source.settings")
-    def test_condense_comments_posts_summary_and_deletes_originals(
+    def test_condense_comments_posts_summary_and_deletes_filtered_only(
         self, mock_settings, mock_get_comments, mock_get_issues, mock_execute, mock_comment, mock_delete
     ):
-        """Test that _condense_comments() posts a summary to GitHub and deletes ALL original comments."""
+        """Test that _condense_comments() posts a summary and deletes only filtered comments."""
         mock_settings.github_issue_worker_required_label = "test-label"
         mock_settings.github_issue_worker_allowed_creator = "test-user"
 
@@ -368,7 +368,7 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
-        # Multiple comments from allowed creator + one from other user (ALL should be deleted)
+        # Multiple comments from allowed creator + one from other user
         mock_get_comments.return_value = [
             {"author": "test-user", "body": "Comment 1", "id": 100},
             {"author": "test-user", "body": "Comment 2", "id": 200},
@@ -383,11 +383,12 @@ class TestGitHubTaskSource:
         assert tasks[0].comments == ["Condensed summary"]
         # Verify the condensed summary was posted as a new comment
         mock_comment.assert_called_once_with(Path("/test"), 1, "Condensed summary")
-        # Verify ALL comments were deleted (not just filtered ones)
-        assert mock_delete.call_count == 3
+        # Verify only filtered comments (from allowed creator) were deleted, not all comments
+        assert mock_delete.call_count == 2
         mock_delete.assert_any_call(Path("/test"), 1, 100)
         mock_delete.assert_any_call(Path("/test"), 1, 200)
-        mock_delete.assert_any_call(Path("/test"), 1, 300)
+        # Comment from other-user should NOT be deleted
+        assert (Path("/test"), 1, 300) not in [(c[0][0], c[0][1], c[0][2]) for c in mock_delete.call_args_list]
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -208,8 +208,8 @@ class TestGitHubTaskSource:
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")
     @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
     @patch("auto_slopp.workers.github_task_source.settings")
-    def test_get_tasks_condenses_all_comments(self, mock_settings, mock_execute, mock_get_comments, mock_get_issues):
-        """Test that ALL comments are condensed into a single comment."""
+    def test_get_tasks_condenses_author_comments(self, mock_settings, mock_execute, mock_get_comments, mock_get_issues):
+        """Test that comments from issue author/allowed creator are condensed."""
         mock_settings.github_issue_worker_required_label = "test-label"
         mock_settings.github_issue_worker_allowed_creator = "test-user"
 
@@ -223,9 +223,11 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
+        # Multiple comments from allowed creator + one from other user (should be ignored)
         mock_get_comments.return_value = [
-            {"author": "test-user", "body": "Author comment", "id": 1},
-            {"author": "other-user", "body": "Other comment", "id": 2},
+            {"author": "test-user", "body": "Author comment 1", "id": 1},
+            {"author": "test-user", "body": "Author comment 2", "id": 2},
+            {"author": "other-user", "body": "Other comment", "id": 3},
         ]
         mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
 
@@ -289,9 +291,11 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
+        # Multiple comments from allowed creator + one from other user (should be ignored)
         mock_get_comments.return_value = [
             {"author": "test-user", "body": "Comment 1", "id": 1},
-            {"author": "other-user", "body": "Comment 2", "id": 2},
+            {"author": "test-user", "body": "Comment 2", "id": 2},
+            {"author": "other-user", "body": "Other comment", "id": 3},
         ]
         mock_execute.return_value = {"stdout": "", "success": True}
 
@@ -301,6 +305,7 @@ class TestGitHubTaskSource:
         assert len(tasks) == 1
         task = tasks[0]
         assert len(task.comments) == 1
+        # Only filtered comments (from test-user) should be joined in fallback
         assert task.comments[0] == "Comment 1\n\n---\n\nComment 2"
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
@@ -324,9 +329,10 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
+        # Multiple comments from allowed creator to trigger condensation
         mock_get_comments.return_value = [
             {"author": "test-user", "body": "Comment 1", "id": 1},
-            {"author": "other-user", "body": "Comment 2", "id": 2},
+            {"author": "test-user", "body": "Comment 2", "id": 2},
         ]
         mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
 
@@ -348,7 +354,7 @@ class TestGitHubTaskSource:
     def test_condense_comments_posts_summary_and_deletes_originals(
         self, mock_settings, mock_get_comments, mock_get_issues, mock_execute, mock_comment, mock_delete
     ):
-        """Test that _condense_comments() posts a summary to GitHub and deletes original comments."""
+        """Test that _condense_comments() posts a summary to GitHub and deletes original filtered comments."""
         mock_settings.github_issue_worker_required_label = "test-label"
         mock_settings.github_issue_worker_allowed_creator = "test-user"
 
@@ -362,9 +368,11 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
+        # Multiple comments from allowed creator + one from other user (should be ignored, not deleted)
         mock_get_comments.return_value = [
             {"author": "test-user", "body": "Comment 1", "id": 100},
-            {"author": "other-user", "body": "Comment 2", "id": 200},
+            {"author": "test-user", "body": "Comment 2", "id": 200},
+            {"author": "other-user", "body": "Other comment", "id": 300},
         ]
         mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
 
@@ -375,10 +383,83 @@ class TestGitHubTaskSource:
         assert tasks[0].comments == ["Condensed summary"]
         # Verify the condensed summary was posted as a new comment
         mock_comment.assert_called_once_with(Path("/test"), 1, "Condensed summary")
-        # Verify each original comment was deleted
+        # Verify only filtered comments (from test-user) were deleted
         assert mock_delete.call_count == 2
         mock_delete.assert_any_call(Path("/test"), 1, 100)
         mock_delete.assert_any_call(Path("/test"), 1, 200)
+        # Verify other-user's comment was NOT deleted
+        for call in mock_delete.call_args_list:
+            assert call[0][2] != 300
+
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_get_tasks_ignores_comments_from_other_users(self, mock_settings, mock_get_comments, mock_get_issues):
+        """Test that comments from non-author/non-allowed users are ignored and not condensed."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        # Only comments from other users - should result in empty comments list
+        mock_get_comments.return_value = [
+            {"author": "other-user", "body": "Other comment 1", "id": 1},
+            {"author": "another-user", "body": "Other comment 2", "id": 2},
+        ]
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        # No relevant comments, so comments should be empty
+        assert task.comments == []
+
+    @patch("auto_slopp.workers.github_task_source.get_open_issues")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.settings")
+    def test_get_tasks_condenses_only_allowed_creator_comments(
+        self, mock_settings, mock_execute, mock_get_comments, mock_get_issues
+    ):
+        """Test that only comments from issue author or allowed creator are condensed."""
+        mock_settings.github_issue_worker_required_label = "test-label"
+        mock_settings.github_issue_worker_allowed_creator = "test-user"
+
+        mock_issues = [
+            {
+                "number": 1,
+                "title": "Test Issue",
+                "body": "Test Body",
+                "author": {"login": "test-user"},
+                "labels": [{"name": "test-label"}],
+            }
+        ]
+        mock_get_issues.return_value = mock_issues
+        # Comments from issue author (who is also allowed creator) and other users
+        mock_get_comments.return_value = [
+            {"author": "test-user", "body": "Author comment", "id": 1},
+            {"author": "test-user", "body": "Another author comment", "id": 2},
+            {"author": "other-user", "body": "Other comment", "id": 3},
+        ]
+        mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
+
+        task_source = GitHubTaskSource()
+        tasks = task_source.get_tasks(Path("/test"))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert len(task.comments) == 1
+        assert task.comments[0] == "Condensed summary"
+        mock_execute.assert_called_once()
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     def test_get_tasks_returns_empty_on_no_issues(self, mock_get_issues):

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -676,3 +676,144 @@ class TestGitHubTaskSource:
         ]
 
         assert task_source._has_prs(Path("/test"), 42) is False
+
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_filters_by_author_only(self, mock_get_comments, mock_execute):
+        """Test that _condense_comments filters to only include comments from the issue author."""
+        mock_execute.return_value = {"stdout": "Condensed", "success": True}
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "issue-author"}, "body": "Author comment 1", "id": 1},
+            {"author": {"login": "issue-author"}, "body": "Author comment 2", "id": 2},
+            {"author": {"login": "other-user"}, "body": "Other comment", "id": 3},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        # Should condense the 2 issue-author comments
+        assert len(result) == 1
+        assert result[0] == "Condensed"
+        mock_execute.assert_called_once()
+
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_filters_by_allowed_creator_only(self, mock_get_comments, mock_execute):
+        """Test that _condense_comments filters to only include comments from the allowed creator."""
+        mock_execute.return_value = {"stdout": "Condensed", "success": True}
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "issue-author"}, "body": "Author comment", "id": 1},
+            {"author": {"login": "allowed-creator"}, "body": "Allowed comment 1", "id": 2},
+            {"author": {"login": "allowed-creator"}, "body": "Allowed comment 2", "id": 3},
+            {"author": {"login": "other-user"}, "body": "Other comment", "id": 4},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        # Should condense the 2 allowed-creator comments
+        assert len(result) == 1
+        assert result[0] == "Condensed"
+        mock_execute.assert_called_once()
+
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_mixed_author_and_allowed_creator(self, mock_get_comments, mock_execute):
+        """Test that _condense_comments includes comments from both issue author AND allowed creator."""
+        mock_execute.return_value = {"stdout": "Condensed", "success": True}
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "issue-author"}, "body": "Author comment", "id": 1},
+            {"author": {"login": "allowed-creator"}, "body": "Allowed comment", "id": 2},
+            {"author": {"login": "other-user"}, "body": "Other comment", "id": 3},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        # Should condense both the issue-author and allowed-creator comments (2 total)
+        assert len(result) == 1
+        assert result[0] == "Condensed"
+        mock_execute.assert_called_once()
+
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_no_matching_author(self, mock_get_comments):
+        """Test that _condense_comments returns empty when no comments match author or allowed creator."""
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "other-user"}, "body": "Other comment 1", "id": 1},
+            {"author": {"login": "another-user"}, "body": "Other comment 2", "id": 2},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        assert result == []
+
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_single_matching_comment(self, mock_get_comments):
+        """Test that _condense_comments returns single comment without condensing."""
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "issue-author"}, "body": "Single comment", "id": 1},
+            {"author": {"login": "other-user"}, "body": "Other comment", "id": 2},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        assert result == ["Single comment"]
+
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_empty_comments_list(self, mock_get_comments):
+        """Test that _condense_comments returns empty when there are no comments."""
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = []
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        assert result == []
+
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_handles_none_author(self, mock_get_comments):
+        """Test that _condense_comments handles comments with None author gracefully."""
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": None, "body": "Comment without author", "id": 1},
+            {"author": {"login": "issue-author"}, "body": "Author comment", "id": 2},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        assert result == ["Author comment"]
+
+    @patch("auto_slopp.workers.github_task_source.comment_on_issue")
+    @patch("auto_slopp.workers.github_task_source.delete_issue_comment")
+    @patch("auto_slopp.workers.github_task_source.execute_with_instructions")
+    @patch("auto_slopp.workers.github_task_source.get_issue_comments")
+    def test_condense_comments_deletes_only_filtered_comments(
+        self, mock_get_comments, mock_execute, mock_delete, mock_comment
+    ):
+        """Test that _condense_comments deletes only comments from author/allowed creator."""
+        mock_execute.return_value = {"stdout": "Condensed", "success": True}
+        task_source = GitHubTaskSource()
+
+        mock_get_comments.return_value = [
+            {"author": {"login": "issue-author"}, "body": "Author comment 1", "id": 100},
+            {"author": {"login": "issue-author"}, "body": "Author comment 2", "id": 101},
+            {"author": {"login": "other-user"}, "body": "Other comment", "id": 200},
+        ]
+
+        result = task_source._condense_comments(Path("/test"), 42, "issue-author", "allowed-creator")
+
+        assert result == ["Condensed"]
+        # Only the author's comments should be deleted, not the other user's
+        assert mock_delete.call_count == 2
+        mock_delete.assert_any_call(Path("/test"), 42, 100)
+        mock_delete.assert_any_call(Path("/test"), 42, 101)
+        # Summary should be posted
+        mock_comment.assert_called_with(Path("/test"), 42, "Condensed")

--- a/tests/test_github_task_source.py
+++ b/tests/test_github_task_source.py
@@ -354,7 +354,7 @@ class TestGitHubTaskSource:
     def test_condense_comments_posts_summary_and_deletes_originals(
         self, mock_settings, mock_get_comments, mock_get_issues, mock_execute, mock_comment, mock_delete
     ):
-        """Test that _condense_comments() posts a summary to GitHub and deletes original filtered comments."""
+        """Test that _condense_comments() posts a summary to GitHub and deletes ALL original comments."""
         mock_settings.github_issue_worker_required_label = "test-label"
         mock_settings.github_issue_worker_allowed_creator = "test-user"
 
@@ -368,7 +368,7 @@ class TestGitHubTaskSource:
             }
         ]
         mock_get_issues.return_value = mock_issues
-        # Multiple comments from allowed creator + one from other user (should be ignored, not deleted)
+        # Multiple comments from allowed creator + one from other user (ALL should be deleted)
         mock_get_comments.return_value = [
             {"author": "test-user", "body": "Comment 1", "id": 100},
             {"author": "test-user", "body": "Comment 2", "id": 200},
@@ -383,13 +383,11 @@ class TestGitHubTaskSource:
         assert tasks[0].comments == ["Condensed summary"]
         # Verify the condensed summary was posted as a new comment
         mock_comment.assert_called_once_with(Path("/test"), 1, "Condensed summary")
-        # Verify only filtered comments (from test-user) were deleted
-        assert mock_delete.call_count == 2
+        # Verify ALL comments were deleted (not just filtered ones)
+        assert mock_delete.call_count == 3
         mock_delete.assert_any_call(Path("/test"), 1, 100)
         mock_delete.assert_any_call(Path("/test"), 1, 200)
-        # Verify other-user's comment was NOT deleted
-        for call in mock_delete.call_args_list:
-            assert call[0][2] != 300
+        mock_delete.assert_any_call(Path("/test"), 1, 300)
 
     @patch("auto_slopp.workers.github_task_source.get_open_issues")
     @patch("auto_slopp.workers.github_task_source.get_issue_comments")

--- a/tests/test_task_source.py
+++ b/tests/test_task_source.py
@@ -226,7 +226,8 @@ class TestGitHubTaskSource:
         ]
         mock_comments.return_value = [
             {"author": "testuser", "body": "Comment 1"},
-            {"author": "otheruser", "body": "Comment 2"},
+            {"author": "testuser", "body": "Comment 2"},
+            {"author": "otheruser", "body": "Comment 3"},
         ]
         mock_execute.return_value = {"stdout": "Condensed summary", "success": True}
         source = GitHubTaskSource()


### PR DESCRIPTION
# Comments Compression

## Summary

Refactors the `_condense_comments` method in `src/auto_slopp/workers/github_task_source.py` to correctly filter comments by author before condensation. Previously, the method was condensing comments from all authors and deleting all comments. The fix inverts the filtering logic so that:

- Only comments from the **issue author** or **whitelisted author** (`settings.github_issue_worker_allowed_creator`) are included in the condensation
- Comments from other authors are **ignored** and left untouched
- After creating the summary, only comments from the issue author and whitelisted author are **deleted**
- The original comments are replaced with a single summary comment

## Changes Made

### Modified Files

- `src/auto_slopp/workers/github_task_source.py`
  - Updated `_condense_comments` to accept `issue_author_login` and `allowed_creator` parameters
  - Fixed filtering logic to only condense comments from the issue author and whitelisted author
  - Updated `delete_issue_comment` calls to only target author/whitelisted comments
  - Updated `get_tasks` to retrieve and pass `settings.github_issue_worker_allowed_creator` to `_condense_comments`

### Added Tests

- `tests/test_github_task_source.py`
  - Test: Comments from issue author are condensed and deleted
  - Test: Comments from whitelisted author are condensed and deleted
  - Test: Comments from other authors are ignored and NOT deleted
  - Test: Mixed scenario (author + whitelisted + other) condenses author/whitelisted, ignores other
  - Test: No author/whitelisted comments results in no summary posted and no deletions
  - Test: Only author/whitelisted comments results in single summary, all originals deleted
  - Tests verify correct calls to `comment_on_issue` and `delete_issue_comment`

### Documentation

- Updated `README.md` and other relevant documentation with the new behavior

## Test Verification

All tests pass successfully:

```bash
make test
```

- ✅ All unit tests for the new filtering behavior pass
- ✅ Tests cover edge cases: empty author/whitelisted comments, mixed authorship, single author only
- ✅ Integration tests verify correct GitHub API calls (`comment_on_issue`, `delete_issue_comment`)

## Completed Steps

- [x] Modify `_condense_comments` to filter comments by author
- [x] Update `get_tasks` to pass the allowed creator to `_condense_comments`
- [x] Add unit tests for the new filtering behavior
- [x] Update README.md and documentation
- [x] Run `make test` and confirm success

## Related

Closes #384