### PR TITLE
fix: use databaseId for comment deletion instead of node ID

### DIFF
--- a/src/auto_slopp/utils/github_operations.py
+++ b/src/auto_slopp/utils/github_operations.py
@@ -140,12 +140,14 @@ def get_issue_comments(repo_dir: Path, issue_number: int) -> List[Dict[str, Any]
         GitHubOperationError: If gh command fails
     """
     try:
+        # Use GraphQL API to get comments with databaseId (needed for deletion)
+        # gh issue view --json comments doesn't expose databaseId
         result = _run_gh_command(
             repo_dir,
-            "issue",
-            "view",
-            str(issue_number),
-            "--json=comments",
+            "api",
+            "graphql",
+            "-f",
+            f'query={{ repository(owner: "{settings.github_issue_worker_allowed_creator}", name: "{repo_dir.name}") {{ issue(number: {issue_number}}) {{ comments(first: 100) {{ nodes {{ id databaseId body author {{ login }} createdAt }} }} }} }} }}',
             check=False,
         )
 
@@ -155,8 +157,14 @@ def get_issue_comments(repo_dir: Path, issue_number: int) -> List[Dict[str, Any]
             return []
 
         data = json.loads(result.stdout)
-        # Extract comments from the issue view response
-        raw_comments = data.get("comments", [])
+        # Extract comments from GraphQL response
+        raw_comments = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("issue", {})
+            .get("comments", {})
+            .get("nodes", [])
+        )
         logger.debug(
             f"[GetComments] Fetched {len(raw_comments)} raw comments for issue #{issue_number} in {repo_dir.name}"
         )
@@ -167,6 +175,7 @@ def get_issue_comments(repo_dir: Path, issue_number: int) -> List[Dict[str, Any]
             comments.append(
                 {
                     "id": comment.get("id"),
+                    "databaseId": comment.get("databaseId"),
                     "body": comment.get("body", ""),
                     "author": comment.get("author", {}).get("login") if comment.get("author") else None,
                     "createdAt": comment.get("createdAt"),

--- a/src/auto_slopp/workers/github_task_source.py
+++ b/src/auto_slopp/workers/github_task_source.py
@@ -152,7 +152,7 @@ class GitHubTaskSource(TaskSource):
         # Delete only the filtered comments (from issue author or allowed creator)
         logger.debug(f"[Condense] Deleting {len(filtered_comments)} original comments for issue #{issue_number}")
         for comment in filtered_comments:
-            cid = comment.get("id")
+            cid = comment.get("databaseId")
             if cid is not None:
                 logger.debug(f"[Condense] Deleting comment {cid} for issue #{issue_number}")
                 delete_issue_comment(repo_path, issue_number, cid)


### PR DESCRIPTION
The GitHub REST API DELETE /repos/.../issues/comments/{id} endpoint expects the numeric databaseId, not the GraphQL node ID.

- Switch get_issue_comments() to use GraphQL API to fetch databaseId
- Update delete_issue_comment() caller to use databaseId instead of id

This fixes the HTTP 404 errors when trying to delete issue comments.